### PR TITLE
Add warrant token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ import "github.com/warrant-dev/warrant-go/v5"
 import "github.com/warrant-dev/warrant-go/v5/config"
 
 client := warrant.NewClient(config.ClientConfig{
-    ApiKey: "api_test_f5dsKVeYnVSLHGje44zAygqgqXiLJBICbFzCiAg1E=",
+	ApiKey: "api_test_f5dsKVeYnVSLHGje44zAygqgqXiLJBICbFzCiAg1E=",
 	ApiEndpoint: "https://api.warrant.dev",
 	AuthorizeEndpoint: "https://api.warrant.dev",
 	SelfServiceDashEndpoint: "https://self-serve.warrant.dev",
@@ -59,7 +59,7 @@ warrant.AuthorizeEndpoint = "http://localhost:8000"
 // With client initialization
 // Set api and authorize endpoints to http://localhost:8000 and self-service endpoint to http://localhost:8080
 client := warrant.NewClient(config.ClientConfig{
-    ApiKey: "api_test_f5dsKVeYnVSLHGje44zAygqgqXiLJBICbFzCiAg1E=",
+	ApiKey: "api_test_f5dsKVeYnVSLHGje44zAygqgqXiLJBICbFzCiAg1E=",
 	ApiEndpoint: "http://localhost:8000",
 	AuthorizeEndpoint: "http://localhost:8000",
 	SelfServiceDashEndpoint: "http://localhost:8080",

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Use [Warrant](https://warrant.dev/) in server-side Go projects.
 ## Installation
 
 ```shell
-go get github.com/warrant-dev/warrant-go/v4
+go get github.com/warrant-dev/warrant-go/v5
 ```
 
 ## Usage
@@ -17,7 +17,7 @@ You can use the Warrant SDK with or without a client. Instantiating a client all
 ### Without a Client
 
 ```go
-import "github.com/warrant-dev/warrant-go/v4"
+import "github.com/warrant-dev/warrant-go/v5"
 
 // Setup
 warrant.ApiKey = "api_test_f5dsKVeYnVSLHGje44zAygqgqXiLJBICbFzCiAg1E="
@@ -33,8 +33,8 @@ tenant, err := tenant.Create(&tenant.TenantParams{})
 
 Instantiate the Warrant client with your API key to get started:
 ```go
-import "github.com/warrant-dev/warrant-go/v4"
-import "github.com/warrant-dev/warrant-go/v4/config"
+import "github.com/warrant-dev/warrant-go/v5"
+import "github.com/warrant-dev/warrant-go/v5/config"
 
 client := warrant.NewClient(config.ClientConfig{
     ApiKey: "api_test_f5dsKVeYnVSLHGje44zAygqgqXiLJBICbFzCiAg1E=",
@@ -48,8 +48,8 @@ client := warrant.NewClient(config.ClientConfig{
 The API, Authorize, and Self-Service endpoints the SDK makes requests to are configurable via the `warrant.ApiEndpoint`, `warrant.AuthorizeEndpoint`, `warrant.SelfServiceDashEndpoint` attributes:
 
 ```go
-import "github.com/warrant-dev/warrant-go/v4"
-import "github.com/warrant-dev/warrant-go/v4/config"
+import "github.com/warrant-dev/warrant-go/v5"
+import "github.com/warrant-dev/warrant-go/v5/config"
 
 // Without client initialization
 // Set api and authorize endpoints to http://localhost:8000

--- a/apiclient.go
+++ b/apiclient.go
@@ -12,12 +12,12 @@ const (
 	ClientVersion string = "4.0.0"
 )
 
-type WarrantClient struct {
+type ApiClient struct {
 	HttpClient *http.Client
 	Config     ClientConfig
 }
 
-func (client WarrantClient) MakeRequest(method string, path string, payload interface{}, options *RequestOptions) (*http.Response, error) {
+func (client ApiClient) MakeRequest(method string, path string, payload interface{}, options *RequestOptions) (*http.Response, error) {
 	url := client.Config.ApiEndpoint + path
 	if payload == nil {
 		req, err := http.NewRequest(method, url, nil)

--- a/apiclient.go
+++ b/apiclient.go
@@ -17,7 +17,7 @@ type WarrantClient struct {
 	Config     ClientConfig
 }
 
-func (client WarrantClient) MakeRequest(method string, path string, payload interface{}) (*http.Response, error) {
+func (client WarrantClient) MakeRequest(method string, path string, payload interface{}, options *RequestOptions) (*http.Response, error) {
 	url := client.Config.ApiEndpoint + path
 	if payload == nil {
 		req, err := http.NewRequest(method, url, nil)
@@ -26,6 +26,9 @@ func (client WarrantClient) MakeRequest(method string, path string, payload inte
 		}
 		if client.Config.ApiKey != "" {
 			req.Header.Add("Authorization", fmt.Sprintf("ApiKey %s", client.Config.ApiKey))
+		}
+		if options.WarrantToken != "" {
+			req.Header.Add("Warrant-Token", options.WarrantToken)
 		}
 		req.Header.Add("User-Agent", fmt.Sprintf("warrant-go/%s", ClientVersion))
 		resp, err := client.HttpClient.Do(req)
@@ -44,7 +47,13 @@ func (client WarrantClient) MakeRequest(method string, path string, payload inte
 	if err != nil {
 		return nil, WrapError("Unable to create request", err)
 	}
-	req.Header.Add("Authorization", fmt.Sprintf("ApiKey %s", client.Config.ApiKey))
+	if client.Config.ApiKey != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("ApiKey %s", client.Config.ApiKey))
+	}
+	if options.WarrantToken != "" {
+		req.Header.Add("Warrant-Token", options.WarrantToken)
+	}
+	req.Header.Add("User-Agent", fmt.Sprintf("warrant-go/%s", ClientVersion))
 	resp, err := client.HttpClient.Do(req)
 	if err != nil {
 		return nil, WrapError("Error making request", err)

--- a/apiclient.go
+++ b/apiclient.go
@@ -30,31 +30,16 @@ func NewApiClient(config ClientConfig) *ApiClient {
 }
 
 func (client ApiClient) MakeRequest(method string, path string, payload interface{}, options *RequestOptions) (*http.Response, error) {
-	url := client.Config.ApiEndpoint + path
-	if payload == nil {
-		req, err := http.NewRequest(method, url, nil)
+	var requestBody *bytes.Buffer
+	if payload != nil {
+		postBody, err := json.Marshal(payload)
 		if err != nil {
-			return nil, WrapError("Unable to create request", err)
+			return nil, WrapError("Invalid request payload", err)
 		}
-		if client.Config.ApiKey != "" {
-			req.Header.Add("Authorization", fmt.Sprintf("ApiKey %s", client.Config.ApiKey))
-		}
-		if options.WarrantToken != "" {
-			req.Header.Add("Warrant-Token", options.WarrantToken)
-		}
-		req.Header.Add("User-Agent", fmt.Sprintf("warrant-go/%s", ClientVersion))
-		resp, err := client.HttpClient.Do(req)
-		if err != nil {
-			return nil, WrapError("Error making request", err)
-		}
-		return resp, nil
+		requestBody = bytes.NewBuffer(postBody)
 	}
 
-	postBody, err := json.Marshal(payload)
-	if err != nil {
-		return nil, WrapError("Invalid request payload", err)
-	}
-	requestBody := bytes.NewBuffer(postBody)
+	url := client.Config.ApiEndpoint + path
 	req, err := http.NewRequest(method, url, requestBody)
 	if err != nil {
 		return nil, WrapError("Unable to create request", err)
@@ -66,11 +51,11 @@ func (client ApiClient) MakeRequest(method string, path string, payload interfac
 		req.Header.Add("Warrant-Token", options.WarrantToken)
 	}
 	req.Header.Add("User-Agent", fmt.Sprintf("warrant-go/%s", ClientVersion))
+
 	resp, err := client.HttpClient.Do(req)
 	if err != nil {
 		return nil, WrapError("Error making request", err)
 	}
-
 	respStatus := resp.StatusCode
 	if respStatus < 200 || respStatus >= 400 {
 		msg, _ := io.ReadAll(resp.Body)

--- a/apiclient.go
+++ b/apiclient.go
@@ -1,4 +1,4 @@
-package client
+package warrant
 
 import (
 	"bytes"
@@ -6,17 +6,15 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-
-	"github.com/warrant-dev/warrant-go/v4/config"
 )
 
 const (
-	ClientVersion string = "3.1.0"
+	ClientVersion string = "4.0.0"
 )
 
 type WarrantClient struct {
 	HttpClient *http.Client
-	Config     config.ClientConfig
+	Config     ClientConfig
 }
 
 func (client WarrantClient) MakeRequest(method string, path string, payload interface{}) (*http.Response, error) {

--- a/apiclient.go
+++ b/apiclient.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	ClientVersion string = "4.0.0"
+	ClientVersion string = "5.0.0"
 )
 
 type ApiClient struct {

--- a/apiclient.go
+++ b/apiclient.go
@@ -17,6 +17,18 @@ type ApiClient struct {
 	Config     ClientConfig
 }
 
+func NewApiClient(config ClientConfig) *ApiClient {
+	httpClient := config.HttpClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	return &ApiClient{
+		HttpClient: httpClient,
+		Config:     config,
+	}
+}
+
 func (client ApiClient) MakeRequest(method string, path string, payload interface{}, options *RequestOptions) (*http.Response, error) {
 	url := client.Config.ApiEndpoint + path
 	if payload == nil {

--- a/client.go
+++ b/client.go
@@ -11,12 +11,12 @@ import (
 )
 
 type Client struct {
-	warrantClient *WarrantClient
+	apiClient *ApiClient
 }
 
 func NewClient(config ClientConfig) Client {
 	return Client{
-		warrantClient: &WarrantClient{
+		apiClient: &ApiClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},
@@ -24,7 +24,7 @@ func NewClient(config ClientConfig) Client {
 }
 
 func (c Client) Create(params *WarrantParams) (*Warrant, error) {
-	resp, err := c.warrantClient.MakeRequest("POST", "/v1/warrants", params, &RequestOptions{})
+	resp, err := c.apiClient.MakeRequest("POST", "/v1/warrants", params, &RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func Create(params *WarrantParams) (*Warrant, error) {
 }
 
 func (c Client) Delete(params *WarrantParams) error {
-	_, err := c.warrantClient.MakeRequest("DELETE", "/v1/warrants", params, &RequestOptions{})
+	_, err := c.apiClient.MakeRequest("DELETE", "/v1/warrants", params, &RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func (c Client) Query(queryString string, listParams *ListWarrantParams) (*Query
 		return nil, WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/query?q=%s&%s", url.QueryEscape(queryString), queryParams.Encode()), nil, &listParams.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/query?q=%s&%s", url.QueryEscape(queryString), queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +201,7 @@ func CheckHasFeature(params *FeatureCheckParams) (bool, error) {
 }
 
 func (c Client) makeAuthorizeRequest(params *AccessCheckRequest) (*WarrantCheckResult, error) {
-	resp, err := c.warrantClient.MakeRequest("POST", "/v2/authorize", params, &params.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("POST", "/v2/authorize", params, &params.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +227,7 @@ func getClient() Client {
 	}
 
 	return Client{
-		&WarrantClient{
+		&ApiClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},

--- a/client.go
+++ b/client.go
@@ -224,11 +224,12 @@ func getClient() Client {
 		ApiEndpoint:             ApiEndpoint,
 		AuthorizeEndpoint:       AuthorizeEndpoint,
 		SelfServiceDashEndpoint: SelfServiceDashEndpoint,
+		HttpClient:              HttpClient,
 	}
 
 	return Client{
 		&ApiClient{
-			HttpClient: http.DefaultClient,
+			HttpClient: HttpClient,
 			Config:     config,
 		},
 	}

--- a/client.go
+++ b/client.go
@@ -24,7 +24,7 @@ func NewClient(config ClientConfig) Client {
 }
 
 func (c Client) Create(params *WarrantParams) (*Warrant, error) {
-	resp, err := c.warrantClient.MakeRequest("POST", "/v1/warrants", params)
+	resp, err := c.warrantClient.MakeRequest("POST", "/v1/warrants", params, &RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func Create(params *WarrantParams) (*Warrant, error) {
 }
 
 func (c Client) Delete(params *WarrantParams) error {
-	_, err := c.warrantClient.MakeRequest("DELETE", "/v1/warrants", params)
+	_, err := c.warrantClient.MakeRequest("DELETE", "/v1/warrants", params, &RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func (c Client) Query(queryString string, listParams *ListWarrantParams) (*Query
 		return nil, WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/query?q=%s&%s", url.QueryEscape(queryString), queryParams.Encode()), nil)
+	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/query?q=%s&%s", url.QueryEscape(queryString), queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -84,8 +84,9 @@ func Query(queryString string, params *ListWarrantParams) (*QueryWarrantResult, 
 
 func (c Client) Check(params *WarrantCheckParams) (bool, error) {
 	accessCheckRequest := AccessCheckRequest{
-		Warrants: []WarrantCheck{params.WarrantCheck},
-		Debug:    params.Debug,
+		RequestOptions: params.RequestOptions,
+		Warrants:       []WarrantCheck{params.WarrantCheck},
+		Debug:          params.Debug,
 	}
 
 	checkResult, err := c.makeAuthorizeRequest(&accessCheckRequest)
@@ -111,9 +112,10 @@ func (c Client) CheckMany(params *WarrantCheckManyParams) (bool, error) {
 	}
 
 	accessCheckRequest := AccessCheckRequest{
-		Op:       params.Op,
-		Warrants: warrants,
-		Debug:    params.Debug,
+		RequestOptions: params.RequestOptions,
+		Op:             params.Op,
+		Warrants:       warrants,
+		Debug:          params.Debug,
 	}
 
 	checkResult, err := c.makeAuthorizeRequest(&accessCheckRequest)
@@ -134,6 +136,7 @@ func CheckMany(params *WarrantCheckManyParams) (bool, error) {
 
 func (c Client) CheckUserHasPermission(params *PermissionCheckParams) (bool, error) {
 	return c.Check(&WarrantCheckParams{
+		RequestOptions: params.RequestOptions,
 		WarrantCheck: WarrantCheck{
 			Object: Object{
 				ObjectType: ObjectTypePermission,
@@ -156,6 +159,7 @@ func CheckUserHasPermission(params *PermissionCheckParams) (bool, error) {
 
 func (c Client) CheckUserHasRole(params *RoleCheckParams) (bool, error) {
 	return c.Check(&WarrantCheckParams{
+		RequestOptions: params.RequestOptions,
 		WarrantCheck: WarrantCheck{
 			Object: Object{
 				ObjectType: ObjectTypeRole,
@@ -178,6 +182,7 @@ func CheckUserHasRole(params *RoleCheckParams) (bool, error) {
 
 func (c Client) CheckHasFeature(params *FeatureCheckParams) (bool, error) {
 	return c.Check(&WarrantCheckParams{
+		RequestOptions: params.RequestOptions,
 		WarrantCheck: WarrantCheck{
 			Object: Object{
 				ObjectType: ObjectTypeFeature,
@@ -196,7 +201,7 @@ func CheckHasFeature(params *FeatureCheckParams) (bool, error) {
 }
 
 func (c Client) makeAuthorizeRequest(params *AccessCheckRequest) (*WarrantCheckResult, error) {
-	resp, err := c.warrantClient.MakeRequest("POST", "/v2/authorize", params)
+	resp, err := c.warrantClient.MakeRequest("POST", "/v2/authorize", params, &params.RequestOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -10,12 +10,12 @@ import (
 	"github.com/google/go-querystring/query"
 )
 
-type Client struct {
+type WarrantClient struct {
 	apiClient *ApiClient
 }
 
-func NewClient(config ClientConfig) Client {
-	return Client{
+func NewClient(config ClientConfig) WarrantClient {
+	return WarrantClient{
 		apiClient: &ApiClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
@@ -23,7 +23,7 @@ func NewClient(config ClientConfig) Client {
 	}
 }
 
-func (c Client) Create(params *WarrantParams) (*Warrant, error) {
+func (c WarrantClient) Create(params *WarrantParams) (*Warrant, error) {
 	resp, err := c.apiClient.MakeRequest("POST", "/v1/warrants", params, &RequestOptions{})
 	if err != nil {
 		return nil, err
@@ -44,7 +44,7 @@ func Create(params *WarrantParams) (*Warrant, error) {
 	return getClient().Create(params)
 }
 
-func (c Client) Delete(params *WarrantParams) error {
+func (c WarrantClient) Delete(params *WarrantParams) error {
 	_, err := c.apiClient.MakeRequest("DELETE", "/v1/warrants", params, &RequestOptions{})
 	if err != nil {
 		return err
@@ -56,7 +56,7 @@ func Delete(params *WarrantParams) error {
 	return getClient().Delete(params)
 }
 
-func (c Client) Query(queryString string, listParams *ListWarrantParams) (*QueryWarrantResult, error) {
+func (c WarrantClient) Query(queryString string, listParams *ListWarrantParams) (*QueryWarrantResult, error) {
 	queryParams, err := query.Values(listParams)
 	if err != nil {
 		return nil, WrapError("Could not parse listParams", err)
@@ -82,7 +82,7 @@ func Query(queryString string, params *ListWarrantParams) (*QueryWarrantResult, 
 	return getClient().Query(queryString, params)
 }
 
-func (c Client) Check(params *WarrantCheckParams) (bool, error) {
+func (c WarrantClient) Check(params *WarrantCheckParams) (bool, error) {
 	accessCheckRequest := AccessCheckRequest{
 		RequestOptions: params.RequestOptions,
 		Warrants:       []WarrantCheck{params.WarrantCheck},
@@ -105,7 +105,7 @@ func Check(params *WarrantCheckParams) (bool, error) {
 	return getClient().Check(params)
 }
 
-func (c Client) CheckMany(params *WarrantCheckManyParams) (bool, error) {
+func (c WarrantClient) CheckMany(params *WarrantCheckManyParams) (bool, error) {
 	warrants := make([]WarrantCheck, 0)
 	for _, warrantCheck := range params.Warrants {
 		warrants = append(warrants, warrantCheck)
@@ -134,7 +134,7 @@ func CheckMany(params *WarrantCheckManyParams) (bool, error) {
 	return getClient().CheckMany(params)
 }
 
-func (c Client) CheckUserHasPermission(params *PermissionCheckParams) (bool, error) {
+func (c WarrantClient) CheckUserHasPermission(params *PermissionCheckParams) (bool, error) {
 	return c.Check(&WarrantCheckParams{
 		RequestOptions: params.RequestOptions,
 		WarrantCheck: WarrantCheck{
@@ -157,7 +157,7 @@ func CheckUserHasPermission(params *PermissionCheckParams) (bool, error) {
 	return getClient().CheckUserHasPermission(params)
 }
 
-func (c Client) CheckUserHasRole(params *RoleCheckParams) (bool, error) {
+func (c WarrantClient) CheckUserHasRole(params *RoleCheckParams) (bool, error) {
 	return c.Check(&WarrantCheckParams{
 		RequestOptions: params.RequestOptions,
 		WarrantCheck: WarrantCheck{
@@ -180,7 +180,7 @@ func CheckUserHasRole(params *RoleCheckParams) (bool, error) {
 	return getClient().CheckUserHasRole(params)
 }
 
-func (c Client) CheckHasFeature(params *FeatureCheckParams) (bool, error) {
+func (c WarrantClient) CheckHasFeature(params *FeatureCheckParams) (bool, error) {
 	return c.Check(&WarrantCheckParams{
 		RequestOptions: params.RequestOptions,
 		WarrantCheck: WarrantCheck{
@@ -200,7 +200,7 @@ func CheckHasFeature(params *FeatureCheckParams) (bool, error) {
 	return getClient().CheckHasFeature(params)
 }
 
-func (c Client) makeAuthorizeRequest(params *AccessCheckRequest) (*WarrantCheckResult, error) {
+func (c WarrantClient) makeAuthorizeRequest(params *AccessCheckRequest) (*WarrantCheckResult, error) {
 	resp, err := c.apiClient.MakeRequest("POST", "/v2/authorize", params, &params.RequestOptions)
 	if err != nil {
 		return nil, err
@@ -218,7 +218,7 @@ func (c Client) makeAuthorizeRequest(params *AccessCheckRequest) (*WarrantCheckR
 	return &result, nil
 }
 
-func getClient() Client {
+func getClient() WarrantClient {
 	config := ClientConfig{
 		ApiKey:                  ApiKey,
 		ApiEndpoint:             ApiEndpoint,
@@ -227,7 +227,7 @@ func getClient() Client {
 		HttpClient:              HttpClient,
 	}
 
-	return Client{
+	return WarrantClient{
 		&ApiClient{
 			HttpClient: HttpClient,
 			Config:     config,

--- a/client.go
+++ b/client.go
@@ -8,17 +8,15 @@ import (
 	"net/url"
 
 	"github.com/google/go-querystring/query"
-	"github.com/warrant-dev/warrant-go/v4/client"
-	"github.com/warrant-dev/warrant-go/v4/config"
 )
 
 type Client struct {
-	warrantClient *client.WarrantClient
+	warrantClient *WarrantClient
 }
 
-func NewClient(config config.ClientConfig) Client {
+func NewClient(config ClientConfig) Client {
 	return Client{
-		warrantClient: &client.WarrantClient{
+		warrantClient: &WarrantClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},
@@ -32,12 +30,12 @@ func (c Client) Create(params *WarrantParams) (*Warrant, error) {
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, WrapError("Error reading response", err)
 	}
 	var createdWarrant Warrant
 	err = json.Unmarshal([]byte(body), &createdWarrant)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, WrapError("Invalid response from server", err)
 	}
 	return &createdWarrant, nil
 }
@@ -61,7 +59,7 @@ func Delete(params *WarrantParams) error {
 func (c Client) Query(queryString string, listParams *ListWarrantParams) (*QueryWarrantResult, error) {
 	queryParams, err := query.Values(listParams)
 	if err != nil {
-		return nil, client.WrapError("Could not parse listParams", err)
+		return nil, WrapError("Could not parse listParams", err)
 	}
 
 	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/query?q=%s&%s", url.QueryEscape(queryString), queryParams.Encode()), nil)
@@ -70,12 +68,12 @@ func (c Client) Query(queryString string, listParams *ListWarrantParams) (*Query
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, WrapError("Error reading response", err)
 	}
 	var queryResult QueryWarrantResult
 	err = json.Unmarshal([]byte(body), &queryResult)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, WrapError("Invalid response from server", err)
 	}
 	return &queryResult, nil
 }
@@ -205,18 +203,18 @@ func (c Client) makeAuthorizeRequest(params *AccessCheckRequest) (*WarrantCheckR
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, WrapError("Error reading response", err)
 	}
 	var result WarrantCheckResult
 	err = json.Unmarshal([]byte(body), &result)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, WrapError("Invalid response from server", err)
 	}
 	return &result, nil
 }
 
 func getClient() Client {
-	config := config.ClientConfig{
+	config := ClientConfig{
 		ApiKey:                  ApiKey,
 		ApiEndpoint:             ApiEndpoint,
 		AuthorizeEndpoint:       AuthorizeEndpoint,
@@ -224,7 +222,7 @@ func getClient() Client {
 	}
 
 	return Client{
-		&client.WarrantClient{
+		&WarrantClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},

--- a/config.go
+++ b/config.go
@@ -1,5 +1,7 @@
 package warrant
 
+import "net/http"
+
 var ApiKey string
 var ApiEndpoint string = "https://api.warrant.dev"
 var AuthorizeEndpoint string = "https://api.warrant.dev"
@@ -10,4 +12,5 @@ type ClientConfig struct {
 	ApiEndpoint             string
 	AuthorizeEndpoint       string
 	SelfServiceDashEndpoint string
+	HttpClient              *http.Client
 }

--- a/config.go
+++ b/config.go
@@ -6,6 +6,7 @@ var ApiKey string
 var ApiEndpoint string = "https://api.warrant.dev"
 var AuthorizeEndpoint string = "https://api.warrant.dev"
 var SelfServiceDashEndpoint string = "https://self-serve.warrant.dev"
+var HttpClient *http.Client = http.DefaultClient
 
 type ClientConfig struct {
 	ApiKey                  string

--- a/config.go
+++ b/config.go
@@ -4,3 +4,10 @@ var ApiKey string
 var ApiEndpoint string = "https://api.warrant.dev"
 var AuthorizeEndpoint string = "https://api.warrant.dev"
 var SelfServiceDashEndpoint string = "https://self-serve.warrant.dev"
+
+type ClientConfig struct {
+	ApiKey                  string
+	ApiEndpoint             string
+	AuthorizeEndpoint       string
+	SelfServiceDashEndpoint string
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1,8 +1,0 @@
-package config
-
-type ClientConfig struct {
-	ApiKey                  string
-	ApiEndpoint             string
-	AuthorizeEndpoint       string
-	SelfServiceDashEndpoint string
-}

--- a/error.go
+++ b/error.go
@@ -1,4 +1,4 @@
-package client
+package warrant
 
 import "fmt"
 

--- a/examples/live_test.go
+++ b/examples/live_test.go
@@ -4,14 +4,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/warrant-dev/warrant-go/v4"
-	"github.com/warrant-dev/warrant-go/v4/feature"
-	"github.com/warrant-dev/warrant-go/v4/permission"
-	"github.com/warrant-dev/warrant-go/v4/pricingtier"
-	"github.com/warrant-dev/warrant-go/v4/role"
-	"github.com/warrant-dev/warrant-go/v4/session"
-	"github.com/warrant-dev/warrant-go/v4/tenant"
-	"github.com/warrant-dev/warrant-go/v4/user"
+	"github.com/warrant-dev/warrant-go/v5"
+	"github.com/warrant-dev/warrant-go/v5/feature"
+	"github.com/warrant-dev/warrant-go/v5/permission"
+	"github.com/warrant-dev/warrant-go/v5/pricingtier"
+	"github.com/warrant-dev/warrant-go/v5/role"
+	"github.com/warrant-dev/warrant-go/v5/session"
+	"github.com/warrant-dev/warrant-go/v5/tenant"
+	"github.com/warrant-dev/warrant-go/v5/user"
 )
 
 func setup() {

--- a/examples/live_test.go
+++ b/examples/live_test.go
@@ -38,7 +38,9 @@ func TestCrudUsers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	refetchedUser, err := user.Get(user2.UserId)
+	fetchUserParams := &warrant.UserParams{}
+	fetchUserParams.SetWarrantToken("latest")
+	refetchedUser, err := user.Get(user2.UserId, fetchUserParams)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,7 +53,7 @@ func TestCrudUsers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	refetchedUser, err = user.Get("some_id")
+	refetchedUser, err = user.Get("some_id", fetchUserParams)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,6 +62,9 @@ func TestCrudUsers(t *testing.T) {
 
 	users, err := user.ListUsers(&warrant.ListUserParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 10,
 		},
 	})
@@ -78,6 +83,9 @@ func TestCrudUsers(t *testing.T) {
 	}
 	users, err = user.ListUsers(&warrant.ListUserParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 10,
 		},
 	})
@@ -105,7 +113,9 @@ func TestCrudTenants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	refetchedTenant, err := tenant.Get(tenant2.TenantId)
+	fetchTenantParams := &warrant.TenantParams{}
+	fetchTenantParams.SetWarrantToken("latest")
+	refetchedTenant, err := tenant.Get(tenant2.TenantId, fetchTenantParams)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +128,7 @@ func TestCrudTenants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	refetchedTenant, err = tenant.Get("some_tenant_id")
+	refetchedTenant, err = tenant.Get("some_tenant_id", fetchTenantParams)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,6 +137,9 @@ func TestCrudTenants(t *testing.T) {
 
 	tenants, err := tenant.ListTenants(&warrant.ListTenantParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 10,
 		},
 	})
@@ -145,6 +158,9 @@ func TestCrudTenants(t *testing.T) {
 	}
 	tenants, err = tenant.ListTenants(&warrant.ListTenantParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 10,
 		},
 	})
@@ -178,7 +194,9 @@ func TestCrudRoles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	refetchedRole, err := role.Get(viewerRole.RoleId)
+	fetchRoleParams := &warrant.RoleParams{}
+	fetchRoleParams.SetWarrantToken("latest")
+	refetchedRole, err := role.Get(viewerRole.RoleId, fetchRoleParams)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -193,7 +211,7 @@ func TestCrudRoles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	refetchedRole, err = role.Get(viewerRole.RoleId)
+	refetchedRole, err = role.Get(viewerRole.RoleId, fetchRoleParams)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,6 +221,9 @@ func TestCrudRoles(t *testing.T) {
 
 	roles, err := role.ListRoles(&warrant.ListRoleParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 10,
 		},
 	})
@@ -221,6 +242,9 @@ func TestCrudRoles(t *testing.T) {
 	}
 	roles, err = role.ListRoles(&warrant.ListRoleParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 10,
 		},
 	})
@@ -265,7 +289,9 @@ func TestCrudPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	refetchedPermission, err := permission.Get("perm2")
+	fetchPermissionParams := &warrant.PermissionParams{}
+	fetchPermissionParams.SetWarrantToken("latest")
+	refetchedPermission, err := permission.Get("perm2", fetchPermissionParams)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -275,6 +301,9 @@ func TestCrudPermissions(t *testing.T) {
 
 	permissions, err := permission.ListPermissions(&warrant.ListPermissionParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 10,
 		},
 	})
@@ -293,6 +322,9 @@ func TestCrudPermissions(t *testing.T) {
 	}
 	permissions, err = permission.ListPermissions(&warrant.ListPermissionParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 10,
 		},
 	})
@@ -320,7 +352,9 @@ func TestCrudFeatures(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	refetchedFeature, err := feature.Get(feature2.FeatureId)
+	fetchFeatureParams := &warrant.FeatureParams{}
+	fetchFeatureParams.SetWarrantToken("latest")
+	refetchedFeature, err := feature.Get(feature2.FeatureId, fetchFeatureParams)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -328,6 +362,9 @@ func TestCrudFeatures(t *testing.T) {
 
 	features, err := feature.ListFeatures(&warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 10,
 		},
 	})
@@ -346,6 +383,9 @@ func TestCrudFeatures(t *testing.T) {
 	}
 	features, err = feature.ListFeatures(&warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 10,
 		},
 	})
@@ -373,7 +413,9 @@ func TestCrudPricingTiers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	refetchedTier, err := pricingtier.Get(tier2.PricingTierId)
+	fetchTierParams := &warrant.PricingTierParams{}
+	fetchTierParams.SetWarrantToken("latest")
+	refetchedTier, err := pricingtier.Get(tier2.PricingTierId, fetchTierParams)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -381,6 +423,9 @@ func TestCrudPricingTiers(t *testing.T) {
 
 	tiers, err := pricingtier.ListPricingTiers(&warrant.ListPricingTierParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 10,
 		},
 	})
@@ -399,6 +444,9 @@ func TestCrudPricingTiers(t *testing.T) {
 	}
 	tiers, err = pricingtier.ListPricingTiers(&warrant.ListPricingTierParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 10,
 		},
 	})
@@ -485,6 +533,9 @@ func TestMultiTenancy(t *testing.T) {
 	// Assign user1 -> tenant1
 	user1Tenants, err := tenant.ListTenantsForUser(user1.UserId, &warrant.ListTenantParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -494,6 +545,9 @@ func TestMultiTenancy(t *testing.T) {
 	assert.Equal(0, len(user1Tenants))
 	tenant1Users, err := user.ListUsersForTenant(tenant1.TenantId, &warrant.ListUserParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -509,6 +563,9 @@ func TestMultiTenancy(t *testing.T) {
 
 	user1Tenants, err = tenant.ListTenantsForUser(user1.UserId, &warrant.ListTenantParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -519,6 +576,9 @@ func TestMultiTenancy(t *testing.T) {
 	assert.Equal("tenant-1", user1Tenants[0].TenantId)
 	tenant1Users, err = user.ListUsersForTenant(tenant1.TenantId, &warrant.ListUserParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -605,6 +665,9 @@ func TestRBAC(t *testing.T) {
 	// Admin user tests
 	adminUserRoles, err := role.ListRolesForUser(adminUser.UserId, &warrant.ListRoleParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -615,6 +678,9 @@ func TestRBAC(t *testing.T) {
 
 	adminRolePermissions, err := permission.ListPermissionsForRole(adminRole.RoleId, &warrant.ListPermissionParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -624,6 +690,9 @@ func TestRBAC(t *testing.T) {
 	assert.Equal(0, len(adminRolePermissions))
 
 	adminUserHasPermission, err := warrant.CheckUserHasPermission(&warrant.PermissionCheckParams{
+		RequestOptions: warrant.RequestOptions{
+			WarrantToken: "latest",
+		},
 		PermissionId: "create-report",
 		UserId:       adminUser.UserId,
 	})
@@ -645,6 +714,9 @@ func TestRBAC(t *testing.T) {
 
 	adminRolePermissions, err = permission.ListPermissionsForRole(adminRole.RoleId, &warrant.ListPermissionParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -655,6 +727,9 @@ func TestRBAC(t *testing.T) {
 	assert.Equal("create-report", adminRolePermissions[0].PermissionId)
 
 	adminUserHasPermission, err = warrant.CheckUserHasPermission(&warrant.PermissionCheckParams{
+		RequestOptions: warrant.RequestOptions{
+			WarrantToken: "latest",
+		},
 		PermissionId: "create-report",
 		UserId:       adminUser.UserId,
 	})
@@ -665,6 +740,9 @@ func TestRBAC(t *testing.T) {
 
 	adminUserRoles, err = role.ListRolesForUser(adminUser.UserId, &warrant.ListRoleParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -681,6 +759,9 @@ func TestRBAC(t *testing.T) {
 	}
 
 	adminUserHasPermission, err = warrant.CheckUserHasPermission(&warrant.PermissionCheckParams{
+		RequestOptions: warrant.RequestOptions{
+			WarrantToken: "latest",
+		},
 		PermissionId: "create-report",
 		UserId:       adminUser.UserId,
 	})
@@ -691,6 +772,9 @@ func TestRBAC(t *testing.T) {
 
 	adminUserRoles, err = role.ListRolesForUser(adminUser.UserId, &warrant.ListRoleParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -706,6 +790,9 @@ func TestRBAC(t *testing.T) {
 
 	adminUserRoles, err = role.ListRolesForUser(adminUser.UserId, &warrant.ListRoleParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -716,6 +803,9 @@ func TestRBAC(t *testing.T) {
 
 	// Viewer user tests
 	viewerUserHasPermission, err := warrant.CheckUserHasPermission(&warrant.PermissionCheckParams{
+		RequestOptions: warrant.RequestOptions{
+			WarrantToken: "latest",
+		},
 		PermissionId: "view-report",
 		UserId:       viewerUser.UserId,
 	})
@@ -726,6 +816,9 @@ func TestRBAC(t *testing.T) {
 
 	viewerUserPermissions, err := permission.ListPermissionsForUser(viewerUser.UserId, &warrant.ListPermissionParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -741,6 +834,9 @@ func TestRBAC(t *testing.T) {
 	}
 
 	viewerUserHasPermission, err = warrant.CheckUserHasPermission(&warrant.PermissionCheckParams{
+		RequestOptions: warrant.RequestOptions{
+			WarrantToken: "latest",
+		},
 		PermissionId: "view-report",
 		UserId:       viewerUser.UserId,
 	})
@@ -751,6 +847,9 @@ func TestRBAC(t *testing.T) {
 
 	viewerUserPermissions, err = permission.ListPermissionsForUser(viewerUser.UserId, &warrant.ListPermissionParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -767,6 +866,9 @@ func TestRBAC(t *testing.T) {
 	}
 
 	viewerUserHasPermission, err = warrant.CheckUserHasPermission(&warrant.PermissionCheckParams{
+		RequestOptions: warrant.RequestOptions{
+			WarrantToken: "latest",
+		},
 		PermissionId: "view-report",
 		UserId:       viewerUser.UserId,
 	})
@@ -777,6 +879,9 @@ func TestRBAC(t *testing.T) {
 
 	viewerUserPermissions, err = permission.ListPermissionsForUser(viewerUser.UserId, &warrant.ListPermissionParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -866,6 +971,9 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 
 	// Paid user tests
 	paidUserHasFeature, err := warrant.CheckHasFeature(&warrant.FeatureCheckParams{
+		RequestOptions: warrant.RequestOptions{
+			WarrantToken: "latest",
+		},
 		FeatureId: "custom-feature",
 		Subject: warrant.Subject{
 			ObjectType: warrant.ObjectTypeUser,
@@ -879,6 +987,9 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 
 	paidUserFeatures, err := feature.ListFeaturesForUser(paidUser.UserId, &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -894,6 +1005,9 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	}
 
 	paidUserHasFeature, err = warrant.CheckHasFeature(&warrant.FeatureCheckParams{
+		RequestOptions: warrant.RequestOptions{
+			WarrantToken: "latest",
+		},
 		FeatureId: "custom-feature",
 		Subject: warrant.Subject{
 			ObjectType: warrant.ObjectTypeUser,
@@ -907,6 +1021,9 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 
 	paidUserFeatures, err = feature.ListFeaturesForUser(paidUser.UserId, &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -922,6 +1039,9 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	}
 
 	paidUserHasFeature, err = warrant.CheckHasFeature(&warrant.FeatureCheckParams{
+		RequestOptions: warrant.RequestOptions{
+			WarrantToken: "latest",
+		},
 		FeatureId: "custom-feature",
 		Subject: warrant.Subject{
 			ObjectType: warrant.ObjectTypeUser,
@@ -935,6 +1055,9 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 
 	paidUserFeatures, err = feature.ListFeaturesForUser(paidUser.UserId, &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -945,6 +1068,9 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 
 	// Free user tests
 	freeUserHasFeature, err := warrant.CheckHasFeature(&warrant.FeatureCheckParams{
+		RequestOptions: warrant.RequestOptions{
+			WarrantToken: "latest",
+		},
 		FeatureId: "feature-1",
 		Subject: warrant.Subject{
 			ObjectType: warrant.ObjectTypeUser,
@@ -958,6 +1084,9 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 
 	freeTierFeatures, err := feature.ListFeaturesForPricingTier("free", &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -968,6 +1097,9 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 
 	freeUserFeatures, err := feature.ListFeaturesForUser(freeUser.UserId, &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -988,6 +1120,9 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	}
 
 	freeUserHasFeature, err = warrant.CheckHasFeature(&warrant.FeatureCheckParams{
+		RequestOptions: warrant.RequestOptions{
+			WarrantToken: "latest",
+		},
 		FeatureId: "feature-1",
 		Subject: warrant.Subject{
 			ObjectType: warrant.ObjectTypeUser,
@@ -1001,6 +1136,9 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 
 	freeTierFeatures, err = feature.ListFeaturesForPricingTier("free", &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -1011,6 +1149,9 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 
 	freeUserTiers, err := pricingtier.ListPricingTiersForUser(freeUser.UserId, &warrant.ListPricingTierParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -1026,6 +1167,9 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	}
 
 	freeUserHasFeature, err = warrant.CheckHasFeature(&warrant.FeatureCheckParams{
+		RequestOptions: warrant.RequestOptions{
+			WarrantToken: "latest",
+		},
 		FeatureId: "feature-1",
 		Subject: warrant.Subject{
 			ObjectType: warrant.ObjectTypeUser,
@@ -1039,6 +1183,9 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 
 	freeTierFeatures, err = feature.ListFeaturesForPricingTier("free", &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -1049,6 +1196,9 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 
 	freeUserTiers, err = pricingtier.ListPricingTiersForUser(freeUser.UserId, &warrant.ListPricingTierParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -1064,6 +1214,9 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 
 	freeUserTiers, err = pricingtier.ListPricingTiersForUser(freeUser.UserId, &warrant.ListPricingTierParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -1157,6 +1310,9 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 
 	// Paid tenant tests
 	paidTenantHasFeature, err := warrant.CheckHasFeature(&warrant.FeatureCheckParams{
+		RequestOptions: warrant.RequestOptions{
+			WarrantToken: "latest",
+		},
 		FeatureId: "custom-feature",
 		Subject: warrant.Subject{
 			ObjectType: warrant.ObjectTypeTenant,
@@ -1170,6 +1326,9 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 
 	paidTenantFeatures, err := feature.ListFeaturesForTenant(paidTenant.TenantId, &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -1185,6 +1344,9 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	}
 
 	paidTenantHasFeature, err = warrant.CheckHasFeature(&warrant.FeatureCheckParams{
+		RequestOptions: warrant.RequestOptions{
+			WarrantToken: "latest",
+		},
 		FeatureId: "custom-feature",
 		Subject: warrant.Subject{
 			ObjectType: warrant.ObjectTypeTenant,
@@ -1198,6 +1360,9 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 
 	paidTenantFeatures, err = feature.ListFeaturesForTenant(paidTenant.TenantId, &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -1213,6 +1378,9 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	}
 
 	paidTenantHasFeature, err = warrant.CheckHasFeature(&warrant.FeatureCheckParams{
+		RequestOptions: warrant.RequestOptions{
+			WarrantToken: "latest",
+		},
 		FeatureId: "custom-feature",
 		Subject: warrant.Subject{
 			ObjectType: warrant.ObjectTypeTenant,
@@ -1226,6 +1394,9 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 
 	paidTenantFeatures, err = feature.ListFeaturesForTenant(paidTenant.TenantId, &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -1236,6 +1407,9 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 
 	// Free tenant tests
 	freeTenantHasFeature, err := warrant.CheckHasFeature(&warrant.FeatureCheckParams{
+		RequestOptions: warrant.RequestOptions{
+			WarrantToken: "latest",
+		},
 		FeatureId: "feature-1",
 		Subject: warrant.Subject{
 			ObjectType: warrant.ObjectTypeTenant,
@@ -1249,6 +1423,9 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 
 	freeTierFeatures, err := feature.ListFeaturesForPricingTier("free", &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -1259,6 +1436,9 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 
 	freeTenantFeatures, err := feature.ListFeaturesForTenant(freeTenant.TenantId, &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -1279,6 +1459,9 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	}
 
 	freeTenantHasFeature, err = warrant.CheckHasFeature(&warrant.FeatureCheckParams{
+		RequestOptions: warrant.RequestOptions{
+			WarrantToken: "latest",
+		},
 		FeatureId: "feature-1",
 		Subject: warrant.Subject{
 			ObjectType: warrant.ObjectTypeTenant,
@@ -1292,6 +1475,9 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 
 	freeTierFeatures, err = feature.ListFeaturesForPricingTier("free", &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -1302,6 +1488,9 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 
 	freeTenantTiers, err := pricingtier.ListPricingTiersForTenant(freeTenant.TenantId, &warrant.ListPricingTierParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -1317,6 +1506,9 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	}
 
 	freeTenantHasFeature, err = warrant.CheckHasFeature(&warrant.FeatureCheckParams{
+		RequestOptions: warrant.RequestOptions{
+			WarrantToken: "latest",
+		},
 		FeatureId: "feature-1",
 		Subject: warrant.Subject{
 			ObjectType: warrant.ObjectTypeTenant,
@@ -1330,6 +1522,9 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 
 	freeTierFeatures, err = feature.ListFeaturesForPricingTier("free", &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -1340,6 +1535,9 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 
 	freeTenantTiers, err = pricingtier.ListPricingTiersForTenant(freeTenant.TenantId, &warrant.ListPricingTierParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -1355,6 +1553,9 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 
 	freeTenantTiers, err = pricingtier.ListPricingTiersForTenant(freeTenant.TenantId, &warrant.ListPricingTierParams{
 		ListParams: warrant.ListParams{
+			RequestOptions: warrant.RequestOptions{
+				WarrantToken: "latest",
+			},
 			Limit: 100,
 		},
 	})
@@ -1463,6 +1664,9 @@ func TestWarrants(t *testing.T) {
 	}
 
 	checkResult, err := warrant.Check(&warrant.WarrantCheckParams{
+		RequestOptions: warrant.RequestOptions{
+			WarrantToken: "latest",
+		},
 		WarrantCheck: warrant.WarrantCheck{
 			Object: warrant.Object{
 				ObjectType: warrant.ObjectTypePermission,
@@ -1494,6 +1698,9 @@ func TestWarrants(t *testing.T) {
 	}
 
 	checkResult, err = warrant.Check(&warrant.WarrantCheckParams{
+		RequestOptions: warrant.RequestOptions{
+			WarrantToken: "latest",
+		},
 		WarrantCheck: warrant.WarrantCheck{
 			Object: warrant.Object{
 				ObjectType: warrant.ObjectTypePermission,
@@ -1539,6 +1746,9 @@ func TestWarrants(t *testing.T) {
 	}
 
 	checkResult, err = warrant.Check(&warrant.WarrantCheckParams{
+		RequestOptions: warrant.RequestOptions{
+			WarrantToken: "latest",
+		},
 		WarrantCheck: warrant.WarrantCheck{
 			Object: warrant.Object{
 				ObjectType: warrant.ObjectTypePermission,
@@ -1587,6 +1797,9 @@ func TestWarrantPolicies(t *testing.T) {
 	}
 
 	checkResult, err := warrant.Check(&warrant.WarrantCheckParams{
+		RequestOptions: warrant.RequestOptions{
+			WarrantToken: "latest",
+		},
 		WarrantCheck: warrant.WarrantCheck{
 			Object: warrant.Object{
 				ObjectType: warrant.ObjectTypePermission,
@@ -1608,6 +1821,9 @@ func TestWarrantPolicies(t *testing.T) {
 	assert.True(checkResult)
 
 	checkResult, err = warrant.Check(&warrant.WarrantCheckParams{
+		RequestOptions: warrant.RequestOptions{
+			WarrantToken: "latest",
+		},
 		WarrantCheck: warrant.WarrantCheck{
 			Object: warrant.Object{
 				ObjectType: warrant.ObjectTypePermission,

--- a/feature.go
+++ b/feature.go
@@ -19,5 +19,6 @@ type ListFeatureParams struct {
 }
 
 type FeatureParams struct {
+	RequestOptions
 	FeatureId string `json:"featureId"`
 }

--- a/feature/client.go
+++ b/feature/client.go
@@ -8,17 +8,15 @@ import (
 
 	"github.com/google/go-querystring/query"
 	"github.com/warrant-dev/warrant-go/v4"
-	"github.com/warrant-dev/warrant-go/v4/client"
-	"github.com/warrant-dev/warrant-go/v4/config"
 )
 
 type Client struct {
-	warrantClient *client.WarrantClient
+	warrantClient *warrant.WarrantClient
 }
 
-func NewClient(config config.ClientConfig) Client {
+func NewClient(config warrant.ClientConfig) Client {
 	return Client{
-		warrantClient: &client.WarrantClient{
+		warrantClient: &warrant.WarrantClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},
@@ -32,12 +30,12 @@ func (c Client) Create(params *warrant.FeatureParams) (*warrant.Feature, error) 
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var newFeature warrant.Feature
 	err = json.Unmarshal([]byte(body), &newFeature)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return &newFeature, nil
 }
@@ -53,12 +51,12 @@ func (c Client) Get(featureId string) (*warrant.Feature, error) {
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var foundFeature warrant.Feature
 	err = json.Unmarshal([]byte(body), &foundFeature)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return &foundFeature, nil
 }
@@ -75,7 +73,7 @@ func (c Client) Delete(featureId string) error {
 	respStatus := resp.StatusCode
 	if respStatus < 200 || respStatus >= 400 {
 		msg, _ := io.ReadAll(resp.Body)
-		return client.Error{
+		return warrant.Error{
 			Message: fmt.Sprintf("HTTP %d %s", respStatus, string(msg)),
 		}
 	}
@@ -89,7 +87,7 @@ func Delete(featureId string) error {
 func (c Client) ListFeatures(listParams *warrant.ListFeatureParams) ([]warrant.Feature, error) {
 	queryParams, err := query.Values(listParams)
 	if err != nil {
-		return nil, client.WrapError("Could not parse listParams", err)
+		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
 	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/features?%s", queryParams.Encode()), nil)
@@ -98,12 +96,12 @@ func (c Client) ListFeatures(listParams *warrant.ListFeatureParams) ([]warrant.F
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var permissions []warrant.Feature
 	err = json.Unmarshal([]byte(body), &permissions)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return permissions, nil
 }
@@ -115,7 +113,7 @@ func ListFeatures(listParams *warrant.ListFeatureParams) ([]warrant.Feature, err
 func (c Client) ListFeaturesForPricingTier(pricingTierId string, listParams *warrant.ListFeatureParams) ([]warrant.Feature, error) {
 	queryParams, err := query.Values(listParams)
 	if err != nil {
-		return nil, client.WrapError("Could not parse listParams", err)
+		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
 	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/pricing-tiers/%s/features?%s", pricingTierId, queryParams.Encode()), nil)
@@ -124,12 +122,12 @@ func (c Client) ListFeaturesForPricingTier(pricingTierId string, listParams *war
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var features []warrant.Feature
 	err = json.Unmarshal([]byte(body), &features)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return features, nil
 }
@@ -173,7 +171,7 @@ func RemoveFeatureFromPricingTier(featureId string, pricingTierId string) error 
 func (c Client) ListFeaturesForTenant(tenantId string, listParams *warrant.ListFeatureParams) ([]warrant.Feature, error) {
 	queryParams, err := query.Values(listParams)
 	if err != nil {
-		return nil, client.WrapError("Could not parse listParams", err)
+		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
 	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants/%s/features?%s", tenantId, queryParams.Encode()), nil)
@@ -182,12 +180,12 @@ func (c Client) ListFeaturesForTenant(tenantId string, listParams *warrant.ListF
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var features []warrant.Feature
 	err = json.Unmarshal([]byte(body), &features)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return features, nil
 }
@@ -231,7 +229,7 @@ func RemoveFeatureFromTenant(featureId string, tenantId string) error {
 func (c Client) ListFeaturesForUser(userId string, listParams *warrant.ListFeatureParams) ([]warrant.Feature, error) {
 	queryParams, err := query.Values(listParams)
 	if err != nil {
-		return nil, client.WrapError("Could not parse listParams", err)
+		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
 	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/features?%s", userId, queryParams.Encode()), nil)
@@ -240,12 +238,12 @@ func (c Client) ListFeaturesForUser(userId string, listParams *warrant.ListFeatu
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var features []warrant.Feature
 	err = json.Unmarshal([]byte(body), &features)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return features, nil
 }
@@ -287,7 +285,7 @@ func RemoveFeatureFromUser(featureId string, userId string) error {
 }
 
 func getClient() Client {
-	config := config.ClientConfig{
+	config := warrant.ClientConfig{
 		ApiKey:                  warrant.ApiKey,
 		ApiEndpoint:             warrant.ApiEndpoint,
 		AuthorizeEndpoint:       warrant.AuthorizeEndpoint,
@@ -295,7 +293,7 @@ func getClient() Client {
 	}
 
 	return Client{
-		&client.WarrantClient{
+		&warrant.WarrantClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},

--- a/feature/client.go
+++ b/feature/client.go
@@ -11,12 +11,12 @@ import (
 )
 
 type Client struct {
-	warrantClient *warrant.WarrantClient
+	apiClient *warrant.ApiClient
 }
 
 func NewClient(config warrant.ClientConfig) Client {
 	return Client{
-		warrantClient: &warrant.WarrantClient{
+		apiClient: &warrant.ApiClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},
@@ -24,7 +24,7 @@ func NewClient(config warrant.ClientConfig) Client {
 }
 
 func (c Client) Create(params *warrant.FeatureParams) (*warrant.Feature, error) {
-	resp, err := c.warrantClient.MakeRequest("POST", "/v1/features", params, &warrant.RequestOptions{})
+	resp, err := c.apiClient.MakeRequest("POST", "/v1/features", params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func Create(params *warrant.FeatureParams) (*warrant.Feature, error) {
 }
 
 func (c Client) Get(featureId string, params *warrant.FeatureParams) (*warrant.Feature, error) {
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/features/%s", featureId), nil, &params.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/features/%s", featureId), nil, &params.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func Get(featureId string, params *warrant.FeatureParams) (*warrant.Feature, err
 }
 
 func (c Client) Delete(featureId string) error {
-	resp, err := c.warrantClient.MakeRequest("DELETE", fmt.Sprintf("/v1/features/%s", featureId), nil, &warrant.RequestOptions{})
+	resp, err := c.apiClient.MakeRequest("DELETE", fmt.Sprintf("/v1/features/%s", featureId), nil, &warrant.RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -90,7 +90,7 @@ func (c Client) ListFeatures(listParams *warrant.ListFeatureParams) ([]warrant.F
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/features?%s", queryParams.Encode()), nil, &listParams.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/features?%s", queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (c Client) ListFeaturesForPricingTier(pricingTierId string, listParams *war
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/pricing-tiers/%s/features?%s", pricingTierId, queryParams.Encode()), nil, &listParams.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/pricing-tiers/%s/features?%s", pricingTierId, queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func ListFeaturesForPricingTier(pricingTierId string, listParams *warrant.ListFe
 }
 
 func (c Client) AssignFeatureToPricingTier(featureId string, pricingTierId string) (*warrant.Warrant, error) {
-	return warrant.NewClient(c.warrantClient.Config).Create(&warrant.WarrantParams{
+	return warrant.NewClient(c.apiClient.Config).Create(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypeFeature,
 		ObjectId:   featureId,
 		Relation:   "member",
@@ -153,7 +153,7 @@ func AssignFeatureToPricingTier(featureId string, pricingTierId string) (*warran
 }
 
 func (c Client) RemoveFeatureFromPricingTier(featureId string, pricingTierId string) error {
-	return warrant.NewClient(c.warrantClient.Config).Delete(&warrant.WarrantParams{
+	return warrant.NewClient(c.apiClient.Config).Delete(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypeFeature,
 		ObjectId:   featureId,
 		Relation:   "member",
@@ -174,7 +174,7 @@ func (c Client) ListFeaturesForTenant(tenantId string, listParams *warrant.ListF
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants/%s/features?%s", tenantId, queryParams.Encode()), nil, &listParams.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants/%s/features?%s", tenantId, queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +195,7 @@ func ListFeaturesForTenant(tenantId string, listParams *warrant.ListFeatureParam
 }
 
 func (c Client) AssignFeatureToTenant(featureId string, tenantId string) (*warrant.Warrant, error) {
-	return warrant.NewClient(c.warrantClient.Config).Create(&warrant.WarrantParams{
+	return warrant.NewClient(c.apiClient.Config).Create(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypeFeature,
 		ObjectId:   featureId,
 		Relation:   "member",
@@ -211,7 +211,7 @@ func AssignFeatureToTenant(featureId string, tenantId string) (*warrant.Warrant,
 }
 
 func (c Client) RemoveFeatureFromTenant(featureId string, tenantId string) error {
-	return warrant.NewClient(c.warrantClient.Config).Delete(&warrant.WarrantParams{
+	return warrant.NewClient(c.apiClient.Config).Delete(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypeFeature,
 		ObjectId:   featureId,
 		Relation:   "member",
@@ -232,7 +232,7 @@ func (c Client) ListFeaturesForUser(userId string, listParams *warrant.ListFeatu
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/features?%s", userId, queryParams.Encode()), nil, &listParams.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/features?%s", userId, queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +253,7 @@ func ListFeaturesForUser(userId string, listParams *warrant.ListFeatureParams) (
 }
 
 func (c Client) AssignFeatureToUser(featureId string, userId string) (*warrant.Warrant, error) {
-	return warrant.NewClient(c.warrantClient.Config).Create(&warrant.WarrantParams{
+	return warrant.NewClient(c.apiClient.Config).Create(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypeFeature,
 		ObjectId:   featureId,
 		Relation:   "member",
@@ -269,7 +269,7 @@ func AssignFeatureToUser(featureId string, userId string) (*warrant.Warrant, err
 }
 
 func (c Client) RemoveFeatureFromUser(featureId string, userId string) error {
-	return warrant.NewClient(c.warrantClient.Config).Delete(&warrant.WarrantParams{
+	return warrant.NewClient(c.apiClient.Config).Delete(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypeFeature,
 		ObjectId:   featureId,
 		Relation:   "member",
@@ -293,7 +293,7 @@ func getClient() Client {
 	}
 
 	return Client{
-		&warrant.WarrantClient{
+		&warrant.ApiClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},

--- a/feature/client.go
+++ b/feature/client.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 
 	"github.com/google/go-querystring/query"
 	"github.com/warrant-dev/warrant-go/v5"
@@ -16,10 +15,7 @@ type Client struct {
 
 func NewClient(config warrant.ClientConfig) Client {
 	return Client{
-		apiClient: &warrant.ApiClient{
-			HttpClient: http.DefaultClient,
-			Config:     config,
-		},
+		apiClient: warrant.NewApiClient(config),
 	}
 }
 

--- a/feature/client.go
+++ b/feature/client.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 
 	"github.com/google/go-querystring/query"
-	"github.com/warrant-dev/warrant-go/v4"
+	"github.com/warrant-dev/warrant-go/v5"
 )
 
 type Client struct {

--- a/feature/client.go
+++ b/feature/client.go
@@ -24,7 +24,7 @@ func NewClient(config warrant.ClientConfig) Client {
 }
 
 func (c Client) Create(params *warrant.FeatureParams) (*warrant.Feature, error) {
-	resp, err := c.warrantClient.MakeRequest("POST", "/v1/features", params)
+	resp, err := c.warrantClient.MakeRequest("POST", "/v1/features", params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -44,8 +44,8 @@ func Create(params *warrant.FeatureParams) (*warrant.Feature, error) {
 	return getClient().Create(params)
 }
 
-func (c Client) Get(featureId string) (*warrant.Feature, error) {
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/features/%s", featureId), nil)
+func (c Client) Get(featureId string, params *warrant.FeatureParams) (*warrant.Feature, error) {
+	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/features/%s", featureId), nil, &params.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -61,12 +61,12 @@ func (c Client) Get(featureId string) (*warrant.Feature, error) {
 	return &foundFeature, nil
 }
 
-func Get(featureId string) (*warrant.Feature, error) {
-	return getClient().Get(featureId)
+func Get(featureId string, params *warrant.FeatureParams) (*warrant.Feature, error) {
+	return getClient().Get(featureId, params)
 }
 
 func (c Client) Delete(featureId string) error {
-	resp, err := c.warrantClient.MakeRequest("DELETE", fmt.Sprintf("/v1/features/%s", featureId), nil)
+	resp, err := c.warrantClient.MakeRequest("DELETE", fmt.Sprintf("/v1/features/%s", featureId), nil, &warrant.RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -90,7 +90,7 @@ func (c Client) ListFeatures(listParams *warrant.ListFeatureParams) ([]warrant.F
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/features?%s", queryParams.Encode()), nil)
+	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/features?%s", queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (c Client) ListFeaturesForPricingTier(pricingTierId string, listParams *war
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/pricing-tiers/%s/features?%s", pricingTierId, queryParams.Encode()), nil)
+	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/pricing-tiers/%s/features?%s", pricingTierId, queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func (c Client) ListFeaturesForTenant(tenantId string, listParams *warrant.ListF
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants/%s/features?%s", tenantId, queryParams.Encode()), nil)
+	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants/%s/features?%s", tenantId, queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +232,7 @@ func (c Client) ListFeaturesForUser(userId string, listParams *warrant.ListFeatu
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/features?%s", userId, queryParams.Encode()), nil)
+	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/features?%s", userId, queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/feature/client.go
+++ b/feature/client.go
@@ -290,11 +290,12 @@ func getClient() Client {
 		ApiEndpoint:             warrant.ApiEndpoint,
 		AuthorizeEndpoint:       warrant.AuthorizeEndpoint,
 		SelfServiceDashEndpoint: warrant.SelfServiceDashEndpoint,
+		HttpClient:              warrant.HttpClient,
 	}
 
 	return Client{
 		&warrant.ApiClient{
-			HttpClient: http.DefaultClient,
+			HttpClient: warrant.HttpClient,
 			Config:     config,
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/warrant-dev/warrant-go/v4
+module github.com/warrant-dev/warrant-go/v5
 
 go 1.21
 

--- a/list.go
+++ b/list.go
@@ -1,6 +1,7 @@
 package warrant
 
 type ListParams struct {
+	RequestOptions
 	BeforeId    string `json:"beforeId"`
 	BeforeValue string `json:"beforeValue"`
 	AfterId     string `json:"afterId"`

--- a/middleware.go
+++ b/middleware.go
@@ -3,8 +3,6 @@ package warrant
 import (
 	"log"
 	"net/http"
-
-	"github.com/warrant-dev/warrant-go/v4/config"
 )
 
 type GetObjectIdFunc func(r *http.Request) string
@@ -149,7 +147,7 @@ func NewMiddleware(middlewareConfig MiddlewareConfig) *Middleware {
 
 	return &Middleware{
 		config: middlewareConfig,
-		client: NewClient(config.ClientConfig{
+		client: NewClient(ClientConfig{
 			ApiKey:                  middlewareConfig.ApiKey,
 			ApiEndpoint:             ApiEndpoint,
 			AuthorizeEndpoint:       AuthorizeEndpoint,

--- a/middleware.go
+++ b/middleware.go
@@ -22,7 +22,7 @@ type MiddlewareConfig struct {
 
 type Middleware struct {
 	config MiddlewareConfig
-	client Client
+	client WarrantClient
 }
 
 type EnsureIsAuthorizedOptions struct {

--- a/params.go
+++ b/params.go
@@ -1,0 +1,9 @@
+package warrant
+
+type RequestOptions struct {
+	WarrantToken string
+}
+
+func (requestOptions *RequestOptions) SetWarrantToken(token string) {
+	requestOptions.WarrantToken = token
+}

--- a/permission.go
+++ b/permission.go
@@ -21,6 +21,7 @@ type ListPermissionParams struct {
 }
 
 type PermissionParams struct {
+	RequestOptions
 	PermissionId string `json:"permissionId"`
 	Name         string `json:"name,omitempty"`
 	Description  string `json:"description,omitempty"`

--- a/permission/client.go
+++ b/permission/client.go
@@ -246,11 +246,12 @@ func getClient() Client {
 		ApiEndpoint:             warrant.ApiEndpoint,
 		AuthorizeEndpoint:       warrant.AuthorizeEndpoint,
 		SelfServiceDashEndpoint: warrant.SelfServiceDashEndpoint,
+		HttpClient:              warrant.HttpClient,
 	}
 
 	return Client{
 		&warrant.ApiClient{
-			HttpClient: http.DefaultClient,
+			HttpClient: warrant.HttpClient,
 			Config:     config,
 		},
 	}

--- a/permission/client.go
+++ b/permission/client.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 
 	"github.com/google/go-querystring/query"
 	"github.com/warrant-dev/warrant-go/v5"
@@ -16,10 +15,7 @@ type Client struct {
 
 func NewClient(config warrant.ClientConfig) Client {
 	return Client{
-		apiClient: &warrant.ApiClient{
-			HttpClient: http.DefaultClient,
-			Config:     config,
-		},
+		apiClient: warrant.NewApiClient(config),
 	}
 }
 

--- a/permission/client.go
+++ b/permission/client.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 
 	"github.com/google/go-querystring/query"
-	"github.com/warrant-dev/warrant-go/v4"
+	"github.com/warrant-dev/warrant-go/v5"
 )
 
 type Client struct {

--- a/permission/client.go
+++ b/permission/client.go
@@ -24,7 +24,7 @@ func NewClient(config warrant.ClientConfig) Client {
 }
 
 func (c Client) Create(params *warrant.PermissionParams) (*warrant.Permission, error) {
-	resp, err := c.warrantClient.MakeRequest("POST", "/v1/permissions", params)
+	resp, err := c.warrantClient.MakeRequest("POST", "/v1/permissions", params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -44,8 +44,8 @@ func Create(params *warrant.PermissionParams) (*warrant.Permission, error) {
 	return getClient().Create(params)
 }
 
-func (c Client) Get(permissionId string) (*warrant.Permission, error) {
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/permissions/%s", permissionId), nil)
+func (c Client) Get(permissionId string, params *warrant.PermissionParams) (*warrant.Permission, error) {
+	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/permissions/%s", permissionId), nil, &params.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -61,12 +61,12 @@ func (c Client) Get(permissionId string) (*warrant.Permission, error) {
 	return &foundPermission, nil
 }
 
-func Get(permissionId string) (*warrant.Permission, error) {
-	return getClient().Get(permissionId)
+func Get(permissionId string, params *warrant.PermissionParams) (*warrant.Permission, error) {
+	return getClient().Get(permissionId, params)
 }
 
 func (c Client) Update(permissionId string, params *warrant.PermissionParams) (*warrant.Permission, error) {
-	resp, err := c.warrantClient.MakeRequest("PUT", fmt.Sprintf("/v1/permissions/%s", permissionId), params)
+	resp, err := c.warrantClient.MakeRequest("PUT", fmt.Sprintf("/v1/permissions/%s", permissionId), params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func Update(permissionId string, params *warrant.PermissionParams) (*warrant.Per
 }
 
 func (c Client) Delete(permissionId string) error {
-	_, err := c.warrantClient.MakeRequest("DELETE", fmt.Sprintf("/v1/permissions/%s", permissionId), nil)
+	_, err := c.warrantClient.MakeRequest("DELETE", fmt.Sprintf("/v1/permissions/%s", permissionId), nil, &warrant.RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func (c Client) ListPermissions(listParams *warrant.ListPermissionParams) ([]war
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/permissions?%s", queryParams.Encode()), nil)
+	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/permissions?%s", queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (c Client) ListPermissionsForRole(roleId string, listParams *warrant.ListPe
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/roles/%s/permissions?%s", roleId, queryParams.Encode()), nil)
+	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/roles/%s/permissions?%s", roleId, queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func (c Client) ListPermissionsForUser(userId string, listParams *warrant.ListPe
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/permissions?%s", userId, queryParams.Encode()), nil)
+	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/permissions?%s", userId, queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/permission/client.go
+++ b/permission/client.go
@@ -11,12 +11,12 @@ import (
 )
 
 type Client struct {
-	warrantClient *warrant.WarrantClient
+	apiClient *warrant.ApiClient
 }
 
 func NewClient(config warrant.ClientConfig) Client {
 	return Client{
-		warrantClient: &warrant.WarrantClient{
+		apiClient: &warrant.ApiClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},
@@ -24,7 +24,7 @@ func NewClient(config warrant.ClientConfig) Client {
 }
 
 func (c Client) Create(params *warrant.PermissionParams) (*warrant.Permission, error) {
-	resp, err := c.warrantClient.MakeRequest("POST", "/v1/permissions", params, &warrant.RequestOptions{})
+	resp, err := c.apiClient.MakeRequest("POST", "/v1/permissions", params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func Create(params *warrant.PermissionParams) (*warrant.Permission, error) {
 }
 
 func (c Client) Get(permissionId string, params *warrant.PermissionParams) (*warrant.Permission, error) {
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/permissions/%s", permissionId), nil, &params.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/permissions/%s", permissionId), nil, &params.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func Get(permissionId string, params *warrant.PermissionParams) (*warrant.Permis
 }
 
 func (c Client) Update(permissionId string, params *warrant.PermissionParams) (*warrant.Permission, error) {
-	resp, err := c.warrantClient.MakeRequest("PUT", fmt.Sprintf("/v1/permissions/%s", permissionId), params, &warrant.RequestOptions{})
+	resp, err := c.apiClient.MakeRequest("PUT", fmt.Sprintf("/v1/permissions/%s", permissionId), params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func Update(permissionId string, params *warrant.PermissionParams) (*warrant.Per
 }
 
 func (c Client) Delete(permissionId string) error {
-	_, err := c.warrantClient.MakeRequest("DELETE", fmt.Sprintf("/v1/permissions/%s", permissionId), nil, &warrant.RequestOptions{})
+	_, err := c.apiClient.MakeRequest("DELETE", fmt.Sprintf("/v1/permissions/%s", permissionId), nil, &warrant.RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func (c Client) ListPermissions(listParams *warrant.ListPermissionParams) ([]war
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/permissions?%s", queryParams.Encode()), nil, &listParams.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/permissions?%s", queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (c Client) ListPermissionsForRole(roleId string, listParams *warrant.ListPe
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/roles/%s/permissions?%s", roleId, queryParams.Encode()), nil, &listParams.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/roles/%s/permissions?%s", roleId, queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ func ListPermissionsForRole(roleId string, listParams *warrant.ListPermissionPar
 }
 
 func (c Client) AssignPermissionToRole(permissionId string, roleId string) (*warrant.Warrant, error) {
-	return warrant.NewClient(c.warrantClient.Config).Create(&warrant.WarrantParams{
+	return warrant.NewClient(c.apiClient.Config).Create(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypePermission,
 		ObjectId:   permissionId,
 		Relation:   "member",
@@ -167,7 +167,7 @@ func AssignPermissionToRole(permissionId string, roleId string) (*warrant.Warran
 }
 
 func (c Client) RemovePermissionFromRole(permissionId string, roleId string) error {
-	return warrant.NewClient(c.warrantClient.Config).Delete(&warrant.WarrantParams{
+	return warrant.NewClient(c.apiClient.Config).Delete(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypePermission,
 		ObjectId:   permissionId,
 		Relation:   "member",
@@ -188,7 +188,7 @@ func (c Client) ListPermissionsForUser(userId string, listParams *warrant.ListPe
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/permissions?%s", userId, queryParams.Encode()), nil, &listParams.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/permissions?%s", userId, queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +209,7 @@ func ListPermissionsForUser(userId string, listParams *warrant.ListPermissionPar
 }
 
 func (c Client) AssignPermissionToUser(permissionId string, userId string) (*warrant.Warrant, error) {
-	return warrant.NewClient(c.warrantClient.Config).Create(&warrant.WarrantParams{
+	return warrant.NewClient(c.apiClient.Config).Create(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypePermission,
 		ObjectId:   permissionId,
 		Relation:   "member",
@@ -225,7 +225,7 @@ func AssignPermissionToUser(permissionId string, userId string) (*warrant.Warran
 }
 
 func (c Client) RemovePermissionFromUser(permissionId string, userId string) error {
-	return warrant.NewClient(c.warrantClient.Config).Delete(&warrant.WarrantParams{
+	return warrant.NewClient(c.apiClient.Config).Delete(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypePermission,
 		ObjectId:   permissionId,
 		Relation:   "member",
@@ -249,7 +249,7 @@ func getClient() Client {
 	}
 
 	return Client{
-		&warrant.WarrantClient{
+		&warrant.ApiClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},

--- a/permission/client.go
+++ b/permission/client.go
@@ -8,17 +8,15 @@ import (
 
 	"github.com/google/go-querystring/query"
 	"github.com/warrant-dev/warrant-go/v4"
-	"github.com/warrant-dev/warrant-go/v4/client"
-	"github.com/warrant-dev/warrant-go/v4/config"
 )
 
 type Client struct {
-	warrantClient *client.WarrantClient
+	warrantClient *warrant.WarrantClient
 }
 
-func NewClient(config config.ClientConfig) Client {
+func NewClient(config warrant.ClientConfig) Client {
 	return Client{
-		warrantClient: &client.WarrantClient{
+		warrantClient: &warrant.WarrantClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},
@@ -32,12 +30,12 @@ func (c Client) Create(params *warrant.PermissionParams) (*warrant.Permission, e
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var newPermission warrant.Permission
 	err = json.Unmarshal([]byte(body), &newPermission)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return &newPermission, nil
 }
@@ -53,12 +51,12 @@ func (c Client) Get(permissionId string) (*warrant.Permission, error) {
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var foundPermission warrant.Permission
 	err = json.Unmarshal([]byte(body), &foundPermission)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return &foundPermission, nil
 }
@@ -74,12 +72,12 @@ func (c Client) Update(permissionId string, params *warrant.PermissionParams) (*
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var updatedPermission warrant.Permission
 	err = json.Unmarshal([]byte(body), &updatedPermission)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return &updatedPermission, nil
 }
@@ -103,7 +101,7 @@ func Delete(permissionId string) error {
 func (c Client) ListPermissions(listParams *warrant.ListPermissionParams) ([]warrant.Permission, error) {
 	queryParams, err := query.Values(listParams)
 	if err != nil {
-		return nil, client.WrapError("Could not parse listParams", err)
+		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
 	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/permissions?%s", queryParams.Encode()), nil)
@@ -112,12 +110,12 @@ func (c Client) ListPermissions(listParams *warrant.ListPermissionParams) ([]war
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var permissions []warrant.Permission
 	err = json.Unmarshal([]byte(body), &permissions)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return permissions, nil
 }
@@ -129,7 +127,7 @@ func ListPermissions(listParams *warrant.ListPermissionParams) ([]warrant.Permis
 func (c Client) ListPermissionsForRole(roleId string, listParams *warrant.ListPermissionParams) ([]warrant.Permission, error) {
 	queryParams, err := query.Values(listParams)
 	if err != nil {
-		return nil, client.WrapError("Could not parse listParams", err)
+		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
 	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/roles/%s/permissions?%s", roleId, queryParams.Encode()), nil)
@@ -138,12 +136,12 @@ func (c Client) ListPermissionsForRole(roleId string, listParams *warrant.ListPe
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var permissions []warrant.Permission
 	err = json.Unmarshal([]byte(body), &permissions)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return permissions, nil
 }
@@ -187,7 +185,7 @@ func RemovePermissionFromRole(permissionId string, roleId string) error {
 func (c Client) ListPermissionsForUser(userId string, listParams *warrant.ListPermissionParams) ([]warrant.Permission, error) {
 	queryParams, err := query.Values(listParams)
 	if err != nil {
-		return nil, client.WrapError("Could not parse listParams", err)
+		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
 	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/permissions?%s", userId, queryParams.Encode()), nil)
@@ -196,12 +194,12 @@ func (c Client) ListPermissionsForUser(userId string, listParams *warrant.ListPe
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var permissions []warrant.Permission
 	err = json.Unmarshal([]byte(body), &permissions)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return permissions, nil
 }
@@ -243,7 +241,7 @@ func RemovePermissionFromUser(permissionId string, userId string) error {
 }
 
 func getClient() Client {
-	config := config.ClientConfig{
+	config := warrant.ClientConfig{
 		ApiKey:                  warrant.ApiKey,
 		ApiEndpoint:             warrant.ApiEndpoint,
 		AuthorizeEndpoint:       warrant.AuthorizeEndpoint,
@@ -251,7 +249,7 @@ func getClient() Client {
 	}
 
 	return Client{
-		&client.WarrantClient{
+		&warrant.WarrantClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},

--- a/pricingtier.go
+++ b/pricingtier.go
@@ -19,5 +19,6 @@ type ListPricingTierParams struct {
 }
 
 type PricingTierParams struct {
+	RequestOptions
 	PricingTierId string `json:"pricingTierId"`
 }

--- a/pricingtier/client.go
+++ b/pricingtier/client.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 
 	"github.com/google/go-querystring/query"
 	"github.com/warrant-dev/warrant-go/v5"
@@ -16,10 +15,7 @@ type Client struct {
 
 func NewClient(config warrant.ClientConfig) Client {
 	return Client{
-		apiClient: &warrant.ApiClient{
-			HttpClient: http.DefaultClient,
-			Config:     config,
-		},
+		apiClient: warrant.NewApiClient(config),
 	}
 }
 

--- a/pricingtier/client.go
+++ b/pricingtier/client.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 
 	"github.com/google/go-querystring/query"
-	"github.com/warrant-dev/warrant-go/v4"
+	"github.com/warrant-dev/warrant-go/v5"
 )
 
 type Client struct {

--- a/pricingtier/client.go
+++ b/pricingtier/client.go
@@ -225,11 +225,12 @@ func getClient() Client {
 		ApiEndpoint:             warrant.ApiEndpoint,
 		AuthorizeEndpoint:       warrant.AuthorizeEndpoint,
 		SelfServiceDashEndpoint: warrant.SelfServiceDashEndpoint,
+		HttpClient:              warrant.HttpClient,
 	}
 
 	return Client{
 		&warrant.ApiClient{
-			HttpClient: http.DefaultClient,
+			HttpClient: warrant.HttpClient,
 			Config:     config,
 		},
 	}

--- a/pricingtier/client.go
+++ b/pricingtier/client.go
@@ -24,7 +24,7 @@ func NewClient(config warrant.ClientConfig) Client {
 }
 
 func (c Client) Create(params *warrant.PricingTierParams) (*warrant.PricingTier, error) {
-	resp, err := c.warrantClient.MakeRequest("POST", "/v1/pricing-tiers", params)
+	resp, err := c.warrantClient.MakeRequest("POST", "/v1/pricing-tiers", params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -44,8 +44,8 @@ func Create(params *warrant.PricingTierParams) (*warrant.PricingTier, error) {
 	return getClient().Create(params)
 }
 
-func (c Client) Get(pricingTierId string) (*warrant.PricingTier, error) {
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/pricing-tiers/%s", pricingTierId), nil)
+func (c Client) Get(pricingTierId string, params *warrant.PricingTierParams) (*warrant.PricingTier, error) {
+	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/pricing-tiers/%s", pricingTierId), nil, &params.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -61,12 +61,12 @@ func (c Client) Get(pricingTierId string) (*warrant.PricingTier, error) {
 	return &foundPricingTier, nil
 }
 
-func Get(pricingTierId string) (*warrant.PricingTier, error) {
-	return getClient().Get(pricingTierId)
+func Get(pricingTierId string, params *warrant.PricingTierParams) (*warrant.PricingTier, error) {
+	return getClient().Get(pricingTierId, params)
 }
 
 func (c Client) Delete(pricingTierId string) error {
-	_, err := c.warrantClient.MakeRequest("DELETE", fmt.Sprintf("/v1/pricing-tiers/%s", pricingTierId), nil)
+	_, err := c.warrantClient.MakeRequest("DELETE", fmt.Sprintf("/v1/pricing-tiers/%s", pricingTierId), nil, &warrant.RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -83,7 +83,7 @@ func (c Client) ListPricingTiers(listParams *warrant.ListPricingTierParams) ([]w
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/pricing-tiers?%s", queryParams.Encode()), nil)
+	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/pricing-tiers?%s", queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (c Client) ListPricingTiersForTenant(tenantId string, listParams *warrant.L
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants/%s/pricing-tiers?%s", tenantId, queryParams.Encode()), nil)
+	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants/%s/pricing-tiers?%s", tenantId, queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +167,7 @@ func (c Client) ListPricingTiersForUser(userId string, listParams *warrant.ListP
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/pricing-tiers?%s", userId, queryParams.Encode()), nil)
+	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/pricing-tiers?%s", userId, queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pricingtier/client.go
+++ b/pricingtier/client.go
@@ -11,12 +11,12 @@ import (
 )
 
 type Client struct {
-	warrantClient *warrant.WarrantClient
+	apiClient *warrant.ApiClient
 }
 
 func NewClient(config warrant.ClientConfig) Client {
 	return Client{
-		warrantClient: &warrant.WarrantClient{
+		apiClient: &warrant.ApiClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},
@@ -24,7 +24,7 @@ func NewClient(config warrant.ClientConfig) Client {
 }
 
 func (c Client) Create(params *warrant.PricingTierParams) (*warrant.PricingTier, error) {
-	resp, err := c.warrantClient.MakeRequest("POST", "/v1/pricing-tiers", params, &warrant.RequestOptions{})
+	resp, err := c.apiClient.MakeRequest("POST", "/v1/pricing-tiers", params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func Create(params *warrant.PricingTierParams) (*warrant.PricingTier, error) {
 }
 
 func (c Client) Get(pricingTierId string, params *warrant.PricingTierParams) (*warrant.PricingTier, error) {
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/pricing-tiers/%s", pricingTierId), nil, &params.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/pricing-tiers/%s", pricingTierId), nil, &params.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func Get(pricingTierId string, params *warrant.PricingTierParams) (*warrant.Pric
 }
 
 func (c Client) Delete(pricingTierId string) error {
-	_, err := c.warrantClient.MakeRequest("DELETE", fmt.Sprintf("/v1/pricing-tiers/%s", pricingTierId), nil, &warrant.RequestOptions{})
+	_, err := c.apiClient.MakeRequest("DELETE", fmt.Sprintf("/v1/pricing-tiers/%s", pricingTierId), nil, &warrant.RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -83,7 +83,7 @@ func (c Client) ListPricingTiers(listParams *warrant.ListPricingTierParams) ([]w
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/pricing-tiers?%s", queryParams.Encode()), nil, &listParams.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/pricing-tiers?%s", queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (c Client) ListPricingTiersForTenant(tenantId string, listParams *warrant.L
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants/%s/pricing-tiers?%s", tenantId, queryParams.Encode()), nil, &listParams.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants/%s/pricing-tiers?%s", tenantId, queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func ListPricingTiersForTenant(userId string, listParams *warrant.ListPricingTie
 }
 
 func (c Client) AssignPricingTierToTenant(pricingTierId string, tenantId string) (*warrant.Warrant, error) {
-	return warrant.NewClient(c.warrantClient.Config).Create(&warrant.WarrantParams{
+	return warrant.NewClient(c.apiClient.Config).Create(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypePricingTier,
 		ObjectId:   pricingTierId,
 		Relation:   "member",
@@ -146,7 +146,7 @@ func AssignPricingTierToTenant(pricingTierId string, tenantId string) (*warrant.
 }
 
 func (c Client) RemovePricingTierFromTenant(pricingTierId string, tenantId string) error {
-	return warrant.NewClient(c.warrantClient.Config).Delete(&warrant.WarrantParams{
+	return warrant.NewClient(c.apiClient.Config).Delete(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypePricingTier,
 		ObjectId:   pricingTierId,
 		Relation:   "member",
@@ -167,7 +167,7 @@ func (c Client) ListPricingTiersForUser(userId string, listParams *warrant.ListP
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/pricing-tiers?%s", userId, queryParams.Encode()), nil, &listParams.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/pricing-tiers?%s", userId, queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func ListPricingTiersForUser(userId string, listParams *warrant.ListPricingTierP
 }
 
 func (c Client) AssignPricingTierToUser(pricingTierId string, userId string) (*warrant.Warrant, error) {
-	return warrant.NewClient(c.warrantClient.Config).Create(&warrant.WarrantParams{
+	return warrant.NewClient(c.apiClient.Config).Create(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypePricingTier,
 		ObjectId:   pricingTierId,
 		Relation:   "member",
@@ -204,7 +204,7 @@ func AssignPricingTierToUser(pricingTierId string, userId string) (*warrant.Warr
 }
 
 func (c Client) RemovePricingTierFromUser(pricingTierId string, userId string) error {
-	return warrant.NewClient(c.warrantClient.Config).Delete(&warrant.WarrantParams{
+	return warrant.NewClient(c.apiClient.Config).Delete(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypePricingTier,
 		ObjectId:   pricingTierId,
 		Relation:   "member",
@@ -228,7 +228,7 @@ func getClient() Client {
 	}
 
 	return Client{
-		&warrant.WarrantClient{
+		&warrant.ApiClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},

--- a/pricingtier/client.go
+++ b/pricingtier/client.go
@@ -8,17 +8,15 @@ import (
 
 	"github.com/google/go-querystring/query"
 	"github.com/warrant-dev/warrant-go/v4"
-	"github.com/warrant-dev/warrant-go/v4/client"
-	"github.com/warrant-dev/warrant-go/v4/config"
 )
 
 type Client struct {
-	warrantClient *client.WarrantClient
+	warrantClient *warrant.WarrantClient
 }
 
-func NewClient(config config.ClientConfig) Client {
+func NewClient(config warrant.ClientConfig) Client {
 	return Client{
-		warrantClient: &client.WarrantClient{
+		warrantClient: &warrant.WarrantClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},
@@ -32,12 +30,12 @@ func (c Client) Create(params *warrant.PricingTierParams) (*warrant.PricingTier,
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var newPricingTier warrant.PricingTier
 	err = json.Unmarshal([]byte(body), &newPricingTier)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return &newPricingTier, nil
 }
@@ -53,12 +51,12 @@ func (c Client) Get(pricingTierId string) (*warrant.PricingTier, error) {
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var foundPricingTier warrant.PricingTier
 	err = json.Unmarshal([]byte(body), &foundPricingTier)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return &foundPricingTier, nil
 }
@@ -82,7 +80,7 @@ func Delete(pricingTierId string) error {
 func (c Client) ListPricingTiers(listParams *warrant.ListPricingTierParams) ([]warrant.PricingTier, error) {
 	queryParams, err := query.Values(listParams)
 	if err != nil {
-		return nil, client.WrapError("Could not parse listParams", err)
+		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
 	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/pricing-tiers?%s", queryParams.Encode()), nil)
@@ -91,12 +89,12 @@ func (c Client) ListPricingTiers(listParams *warrant.ListPricingTierParams) ([]w
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var permissions []warrant.PricingTier
 	err = json.Unmarshal([]byte(body), &permissions)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return permissions, nil
 }
@@ -108,7 +106,7 @@ func ListPricingTiers(listParams *warrant.ListPricingTierParams) ([]warrant.Pric
 func (c Client) ListPricingTiersForTenant(tenantId string, listParams *warrant.ListPricingTierParams) ([]warrant.PricingTier, error) {
 	queryParams, err := query.Values(listParams)
 	if err != nil {
-		return nil, client.WrapError("Could not parse listParams", err)
+		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
 	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants/%s/pricing-tiers?%s", tenantId, queryParams.Encode()), nil)
@@ -117,12 +115,12 @@ func (c Client) ListPricingTiersForTenant(tenantId string, listParams *warrant.L
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var pricingTiers []warrant.PricingTier
 	err = json.Unmarshal([]byte(body), &pricingTiers)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return pricingTiers, nil
 }
@@ -166,7 +164,7 @@ func RemovePricingTierFromTenant(pricingTierId string, tenantId string) error {
 func (c Client) ListPricingTiersForUser(userId string, listParams *warrant.ListPricingTierParams) ([]warrant.PricingTier, error) {
 	queryParams, err := query.Values(listParams)
 	if err != nil {
-		return nil, client.WrapError("Could not parse listParams", err)
+		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
 	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/pricing-tiers?%s", userId, queryParams.Encode()), nil)
@@ -175,12 +173,12 @@ func (c Client) ListPricingTiersForUser(userId string, listParams *warrant.ListP
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var pricingTiers []warrant.PricingTier
 	err = json.Unmarshal([]byte(body), &pricingTiers)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return pricingTiers, nil
 }
@@ -222,7 +220,7 @@ func RemovePricingTierFromUser(pricingTierId string, userId string) error {
 }
 
 func getClient() Client {
-	config := config.ClientConfig{
+	config := warrant.ClientConfig{
 		ApiKey:                  warrant.ApiKey,
 		ApiEndpoint:             warrant.ApiEndpoint,
 		AuthorizeEndpoint:       warrant.AuthorizeEndpoint,
@@ -230,7 +228,7 @@ func getClient() Client {
 	}
 
 	return Client{
-		&client.WarrantClient{
+		&warrant.WarrantClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},

--- a/role.go
+++ b/role.go
@@ -21,6 +21,7 @@ type ListRoleParams struct {
 }
 
 type RoleParams struct {
+	RequestOptions
 	RoleId      string `json:"roleId"`
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`

--- a/role/client.go
+++ b/role/client.go
@@ -24,7 +24,7 @@ func NewClient(config warrant.ClientConfig) Client {
 }
 
 func (c Client) Create(params *warrant.RoleParams) (*warrant.Role, error) {
-	resp, err := c.warrantClient.MakeRequest("POST", "/v1/roles", params)
+	resp, err := c.warrantClient.MakeRequest("POST", "/v1/roles", params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -44,8 +44,8 @@ func Create(params *warrant.RoleParams) (*warrant.Role, error) {
 	return getClient().Create(params)
 }
 
-func (c Client) Get(roleId string) (*warrant.Role, error) {
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/roles/%s", roleId), nil)
+func (c Client) Get(roleId string, params *warrant.RoleParams) (*warrant.Role, error) {
+	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/roles/%s", roleId), nil, &params.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -61,12 +61,12 @@ func (c Client) Get(roleId string) (*warrant.Role, error) {
 	return &foundRole, nil
 }
 
-func Get(roleId string) (*warrant.Role, error) {
-	return getClient().Get(roleId)
+func Get(roleId string, params *warrant.RoleParams) (*warrant.Role, error) {
+	return getClient().Get(roleId, params)
 }
 
 func (c Client) Update(roleId string, params *warrant.RoleParams) (*warrant.Role, error) {
-	resp, err := c.warrantClient.MakeRequest("PUT", fmt.Sprintf("/v1/roles/%s", roleId), params)
+	resp, err := c.warrantClient.MakeRequest("PUT", fmt.Sprintf("/v1/roles/%s", roleId), params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func Update(roleId string, params *warrant.RoleParams) (*warrant.Role, error) {
 }
 
 func (c Client) Delete(roleId string) error {
-	_, err := c.warrantClient.MakeRequest("DELETE", fmt.Sprintf("/v1/roles/%s", roleId), nil)
+	_, err := c.warrantClient.MakeRequest("DELETE", fmt.Sprintf("/v1/roles/%s", roleId), nil, &warrant.RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func (c Client) ListRoles(listParams *warrant.ListRoleParams) ([]warrant.Role, e
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/roles?%s", queryParams.Encode()), nil)
+	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/roles?%s", queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (c Client) ListRolesForUser(userId string, listParams *warrant.ListRolePara
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/roles?%s", userId, queryParams.Encode()), nil)
+	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/roles?%s", userId, queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/role/client.go
+++ b/role/client.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 
 	"github.com/google/go-querystring/query"
 	"github.com/warrant-dev/warrant-go/v5"
@@ -16,10 +15,7 @@ type Client struct {
 
 func NewClient(config warrant.ClientConfig) Client {
 	return Client{
-		apiClient: &warrant.ApiClient{
-			HttpClient: http.DefaultClient,
-			Config:     config,
-		},
+		apiClient: warrant.NewApiClient(config),
 	}
 }
 

--- a/role/client.go
+++ b/role/client.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 
 	"github.com/google/go-querystring/query"
-	"github.com/warrant-dev/warrant-go/v4"
+	"github.com/warrant-dev/warrant-go/v5"
 )
 
 type Client struct {

--- a/role/client.go
+++ b/role/client.go
@@ -11,12 +11,12 @@ import (
 )
 
 type Client struct {
-	warrantClient *warrant.WarrantClient
+	apiClient *warrant.ApiClient
 }
 
 func NewClient(config warrant.ClientConfig) Client {
 	return Client{
-		warrantClient: &warrant.WarrantClient{
+		apiClient: &warrant.ApiClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},
@@ -24,7 +24,7 @@ func NewClient(config warrant.ClientConfig) Client {
 }
 
 func (c Client) Create(params *warrant.RoleParams) (*warrant.Role, error) {
-	resp, err := c.warrantClient.MakeRequest("POST", "/v1/roles", params, &warrant.RequestOptions{})
+	resp, err := c.apiClient.MakeRequest("POST", "/v1/roles", params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func Create(params *warrant.RoleParams) (*warrant.Role, error) {
 }
 
 func (c Client) Get(roleId string, params *warrant.RoleParams) (*warrant.Role, error) {
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/roles/%s", roleId), nil, &params.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/roles/%s", roleId), nil, &params.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func Get(roleId string, params *warrant.RoleParams) (*warrant.Role, error) {
 }
 
 func (c Client) Update(roleId string, params *warrant.RoleParams) (*warrant.Role, error) {
-	resp, err := c.warrantClient.MakeRequest("PUT", fmt.Sprintf("/v1/roles/%s", roleId), params, &warrant.RequestOptions{})
+	resp, err := c.apiClient.MakeRequest("PUT", fmt.Sprintf("/v1/roles/%s", roleId), params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func Update(roleId string, params *warrant.RoleParams) (*warrant.Role, error) {
 }
 
 func (c Client) Delete(roleId string) error {
-	_, err := c.warrantClient.MakeRequest("DELETE", fmt.Sprintf("/v1/roles/%s", roleId), nil, &warrant.RequestOptions{})
+	_, err := c.apiClient.MakeRequest("DELETE", fmt.Sprintf("/v1/roles/%s", roleId), nil, &warrant.RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func (c Client) ListRoles(listParams *warrant.ListRoleParams) ([]warrant.Role, e
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/roles?%s", queryParams.Encode()), nil, &listParams.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/roles?%s", queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (c Client) ListRolesForUser(userId string, listParams *warrant.ListRolePara
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/roles?%s", userId, queryParams.Encode()), nil, &listParams.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/roles?%s", userId, queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ func ListRolesForUser(userId string, listParams *warrant.ListRoleParams) ([]warr
 }
 
 func (c Client) AssignRoleToUser(roleId string, userId string) (*warrant.Warrant, error) {
-	return warrant.NewClient(c.warrantClient.Config).Create(&warrant.WarrantParams{
+	return warrant.NewClient(c.apiClient.Config).Create(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypeRole,
 		ObjectId:   roleId,
 		Relation:   "member",
@@ -167,7 +167,7 @@ func AssignRoleToUser(roleId string, userId string) (*warrant.Warrant, error) {
 }
 
 func (c Client) RemoveRoleFromUser(roleId string, userId string) error {
-	return warrant.NewClient(c.warrantClient.Config).Delete(&warrant.WarrantParams{
+	return warrant.NewClient(c.apiClient.Config).Delete(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypeRole,
 		ObjectId:   roleId,
 		Relation:   "member",
@@ -191,7 +191,7 @@ func getClient() Client {
 	}
 
 	return Client{
-		&warrant.WarrantClient{
+		&warrant.ApiClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},

--- a/role/client.go
+++ b/role/client.go
@@ -8,17 +8,15 @@ import (
 
 	"github.com/google/go-querystring/query"
 	"github.com/warrant-dev/warrant-go/v4"
-	"github.com/warrant-dev/warrant-go/v4/client"
-	"github.com/warrant-dev/warrant-go/v4/config"
 )
 
 type Client struct {
-	warrantClient *client.WarrantClient
+	warrantClient *warrant.WarrantClient
 }
 
-func NewClient(config config.ClientConfig) Client {
+func NewClient(config warrant.ClientConfig) Client {
 	return Client{
-		warrantClient: &client.WarrantClient{
+		warrantClient: &warrant.WarrantClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},
@@ -32,12 +30,12 @@ func (c Client) Create(params *warrant.RoleParams) (*warrant.Role, error) {
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var newRole warrant.Role
 	err = json.Unmarshal([]byte(body), &newRole)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return &newRole, nil
 }
@@ -53,12 +51,12 @@ func (c Client) Get(roleId string) (*warrant.Role, error) {
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var foundRole warrant.Role
 	err = json.Unmarshal([]byte(body), &foundRole)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return &foundRole, nil
 }
@@ -74,12 +72,12 @@ func (c Client) Update(roleId string, params *warrant.RoleParams) (*warrant.Role
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var updatedRole warrant.Role
 	err = json.Unmarshal([]byte(body), &updatedRole)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return &updatedRole, nil
 }
@@ -103,7 +101,7 @@ func Delete(roleId string) error {
 func (c Client) ListRoles(listParams *warrant.ListRoleParams) ([]warrant.Role, error) {
 	queryParams, err := query.Values(listParams)
 	if err != nil {
-		return nil, client.WrapError("Could not parse listParams", err)
+		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
 	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/roles?%s", queryParams.Encode()), nil)
@@ -112,12 +110,12 @@ func (c Client) ListRoles(listParams *warrant.ListRoleParams) ([]warrant.Role, e
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var roles []warrant.Role
 	err = json.Unmarshal([]byte(body), &roles)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return roles, nil
 }
@@ -129,7 +127,7 @@ func ListRoles(listParams *warrant.ListRoleParams) ([]warrant.Role, error) {
 func (c Client) ListRolesForUser(userId string, listParams *warrant.ListRoleParams) ([]warrant.Role, error) {
 	queryParams, err := query.Values(listParams)
 	if err != nil {
-		return nil, client.WrapError("Could not parse listParams", err)
+		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
 	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/roles?%s", userId, queryParams.Encode()), nil)
@@ -138,12 +136,12 @@ func (c Client) ListRolesForUser(userId string, listParams *warrant.ListRolePara
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var roles []warrant.Role
 	err = json.Unmarshal([]byte(body), &roles)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return roles, nil
 }
@@ -185,7 +183,7 @@ func RemoveRoleFromUser(roleId string, userId string) error {
 }
 
 func getClient() Client {
-	config := config.ClientConfig{
+	config := warrant.ClientConfig{
 		ApiKey:                  warrant.ApiKey,
 		ApiEndpoint:             warrant.ApiEndpoint,
 		AuthorizeEndpoint:       warrant.AuthorizeEndpoint,
@@ -193,7 +191,7 @@ func getClient() Client {
 	}
 
 	return Client{
-		&client.WarrantClient{
+		&warrant.WarrantClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},

--- a/role/client.go
+++ b/role/client.go
@@ -188,11 +188,12 @@ func getClient() Client {
 		ApiEndpoint:             warrant.ApiEndpoint,
 		AuthorizeEndpoint:       warrant.AuthorizeEndpoint,
 		SelfServiceDashEndpoint: warrant.SelfServiceDashEndpoint,
+		HttpClient:              warrant.HttpClient,
 	}
 
 	return Client{
 		&warrant.ApiClient{
-			HttpClient: http.DefaultClient,
+			HttpClient: warrant.HttpClient,
 			Config:     config,
 		},
 	}

--- a/session/client.go
+++ b/session/client.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/warrant-dev/warrant-go/v4"
+	"github.com/warrant-dev/warrant-go/v5"
 )
 
 type Client struct {

--- a/session/client.go
+++ b/session/client.go
@@ -28,7 +28,7 @@ func (c Client) CreateAuthorizationSession(params *warrant.AuthorizationSessionP
 		"userId": params.UserId,
 		"ttl":    params.TTL,
 	}
-	resp, err := c.warrantClient.MakeRequest("POST", "/v1/sessions", sessionParams)
+	resp, err := c.warrantClient.MakeRequest("POST", "/v1/sessions", sessionParams, &warrant.RequestOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -63,7 +63,7 @@ func (c Client) CreateSelfServiceSession(params *warrant.SelfServiceSessionParam
 		sessionParams["objectId"] = params.ObjectId
 	}
 
-	resp, err := c.warrantClient.MakeRequest("POST", "/v1/sessions", sessionParams)
+	resp, err := c.warrantClient.MakeRequest("POST", "/v1/sessions", sessionParams, &warrant.RequestOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/session/client.go
+++ b/session/client.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 
 	"github.com/warrant-dev/warrant-go/v5"
 )
@@ -15,10 +14,7 @@ type Client struct {
 
 func NewClient(config warrant.ClientConfig) Client {
 	return Client{
-		apiClient: &warrant.ApiClient{
-			HttpClient: http.DefaultClient,
-			Config:     config,
-		},
+		apiClient: warrant.NewApiClient(config),
 	}
 }
 

--- a/session/client.go
+++ b/session/client.go
@@ -89,11 +89,12 @@ func getClient() Client {
 		ApiEndpoint:             warrant.ApiEndpoint,
 		AuthorizeEndpoint:       warrant.AuthorizeEndpoint,
 		SelfServiceDashEndpoint: warrant.SelfServiceDashEndpoint,
+		HttpClient:              warrant.HttpClient,
 	}
 
 	return Client{
 		&warrant.ApiClient{
-			HttpClient: http.DefaultClient,
+			HttpClient: warrant.HttpClient,
 			Config:     config,
 		},
 	}

--- a/session/client.go
+++ b/session/client.go
@@ -10,12 +10,12 @@ import (
 )
 
 type Client struct {
-	warrantClient *warrant.WarrantClient
+	apiClient *warrant.ApiClient
 }
 
 func NewClient(config warrant.ClientConfig) Client {
 	return Client{
-		warrantClient: &warrant.WarrantClient{
+		apiClient: &warrant.ApiClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},
@@ -28,7 +28,7 @@ func (c Client) CreateAuthorizationSession(params *warrant.AuthorizationSessionP
 		"userId": params.UserId,
 		"ttl":    params.TTL,
 	}
-	resp, err := c.warrantClient.MakeRequest("POST", "/v1/sessions", sessionParams, &warrant.RequestOptions{})
+	resp, err := c.apiClient.MakeRequest("POST", "/v1/sessions", sessionParams, &warrant.RequestOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -63,7 +63,7 @@ func (c Client) CreateSelfServiceSession(params *warrant.SelfServiceSessionParam
 		sessionParams["objectId"] = params.ObjectId
 	}
 
-	resp, err := c.warrantClient.MakeRequest("POST", "/v1/sessions", sessionParams, &warrant.RequestOptions{})
+	resp, err := c.apiClient.MakeRequest("POST", "/v1/sessions", sessionParams, &warrant.RequestOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -92,7 +92,7 @@ func getClient() Client {
 	}
 
 	return Client{
-		&warrant.WarrantClient{
+		&warrant.ApiClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},

--- a/session/client.go
+++ b/session/client.go
@@ -7,17 +7,15 @@ import (
 	"net/http"
 
 	"github.com/warrant-dev/warrant-go/v4"
-	"github.com/warrant-dev/warrant-go/v4/client"
-	"github.com/warrant-dev/warrant-go/v4/config"
 )
 
 type Client struct {
-	warrantClient *client.WarrantClient
+	warrantClient *warrant.WarrantClient
 }
 
-func NewClient(config config.ClientConfig) Client {
+func NewClient(config warrant.ClientConfig) Client {
 	return Client{
-		warrantClient: &client.WarrantClient{
+		warrantClient: &warrant.WarrantClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},
@@ -36,12 +34,12 @@ func (c Client) CreateAuthorizationSession(params *warrant.AuthorizationSessionP
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", client.WrapError("Error reading response", err)
+		return "", warrant.WrapError("Error reading response", err)
 	}
 	var response map[string]string
 	err = json.Unmarshal([]byte(body), &response)
 	if err != nil {
-		return "", client.WrapError("Invalid response from server", err)
+		return "", warrant.WrapError("Invalid response from server", err)
 	}
 	return response["token"], nil
 }
@@ -71,12 +69,12 @@ func (c Client) CreateSelfServiceSession(params *warrant.SelfServiceSessionParam
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", client.WrapError("Error reading response", err)
+		return "", warrant.WrapError("Error reading response", err)
 	}
 	var response map[string]string
 	err = json.Unmarshal([]byte(body), &response)
 	if err != nil {
-		return "", client.WrapError("Invalid response from server", err)
+		return "", warrant.WrapError("Invalid response from server", err)
 	}
 	return fmt.Sprintf("%s/%s?redirectUrl=%s", warrant.SelfServiceDashEndpoint, response["token"], params.RedirectUrl), nil
 }
@@ -86,7 +84,7 @@ func CreateSelfServiceSession(params *warrant.SelfServiceSessionParams) (string,
 }
 
 func getClient() Client {
-	config := config.ClientConfig{
+	config := warrant.ClientConfig{
 		ApiKey:                  warrant.ApiKey,
 		ApiEndpoint:             warrant.ApiEndpoint,
 		AuthorizeEndpoint:       warrant.AuthorizeEndpoint,
@@ -94,7 +92,7 @@ func getClient() Client {
 	}
 
 	return Client{
-		&client.WarrantClient{
+		&warrant.WarrantClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},

--- a/tenant.go
+++ b/tenant.go
@@ -23,6 +23,7 @@ type ListTenantParams struct {
 }
 
 type TenantParams struct {
+	RequestOptions
 	TenantId string `json:"tenantId,omitempty"`
 	Name     string `json:"name,omitempty"`
 }

--- a/tenant/client.go
+++ b/tenant/client.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 
 	"github.com/google/go-querystring/query"
 	"github.com/warrant-dev/warrant-go/v5"
@@ -16,10 +15,7 @@ type Client struct {
 
 func NewClient(config warrant.ClientConfig) Client {
 	return Client{
-		apiClient: &warrant.ApiClient{
-			HttpClient: http.DefaultClient,
-			Config:     config,
-		},
+		apiClient: warrant.NewApiClient(config),
 	}
 }
 

--- a/tenant/client.go
+++ b/tenant/client.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 
 	"github.com/google/go-querystring/query"
-	"github.com/warrant-dev/warrant-go/v4"
+	"github.com/warrant-dev/warrant-go/v5"
 )
 
 type Client struct {

--- a/tenant/client.go
+++ b/tenant/client.go
@@ -11,12 +11,12 @@ import (
 )
 
 type Client struct {
-	warrantClient *warrant.WarrantClient
+	apiClient *warrant.ApiClient
 }
 
 func NewClient(config warrant.ClientConfig) Client {
 	return Client{
-		warrantClient: &warrant.WarrantClient{
+		apiClient: &warrant.ApiClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},
@@ -24,7 +24,7 @@ func NewClient(config warrant.ClientConfig) Client {
 }
 
 func (c Client) Create(params *warrant.TenantParams) (*warrant.Tenant, error) {
-	resp, err := c.warrantClient.MakeRequest("POST", "/v1/tenants", params, &warrant.RequestOptions{})
+	resp, err := c.apiClient.MakeRequest("POST", "/v1/tenants", params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func Create(params *warrant.TenantParams) (*warrant.Tenant, error) {
 }
 
 func (c Client) BatchCreate(params []warrant.TenantParams) ([]warrant.Tenant, error) {
-	resp, err := c.warrantClient.MakeRequest("POST", "/v1/tenants", params, &warrant.RequestOptions{})
+	resp, err := c.apiClient.MakeRequest("POST", "/v1/tenants", params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func BatchCreate(params []warrant.TenantParams) ([]warrant.Tenant, error) {
 }
 
 func (c Client) Get(tenantId string, params *warrant.TenantParams) (*warrant.Tenant, error) {
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants/%s", tenantId), nil, &params.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants/%s", tenantId), nil, &params.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func Get(tenantId string, params *warrant.TenantParams) (*warrant.Tenant, error)
 }
 
 func (c Client) Update(tenantId string, params *warrant.TenantParams) (*warrant.Tenant, error) {
-	resp, err := c.warrantClient.MakeRequest("PUT", fmt.Sprintf("/v1/tenants/%s", tenantId), params, &warrant.RequestOptions{})
+	resp, err := c.apiClient.MakeRequest("PUT", fmt.Sprintf("/v1/tenants/%s", tenantId), params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func Update(tenantId string, params *warrant.TenantParams) (*warrant.Tenant, err
 }
 
 func (c Client) Delete(tenantId string) error {
-	resp, err := c.warrantClient.MakeRequest("DELETE", fmt.Sprintf("/v1/tenants/%s", tenantId), nil, &warrant.RequestOptions{})
+	resp, err := c.apiClient.MakeRequest("DELETE", fmt.Sprintf("/v1/tenants/%s", tenantId), nil, &warrant.RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -132,7 +132,7 @@ func (c Client) ListTenants(listParams *warrant.ListTenantParams) ([]warrant.Ten
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants?%s", queryParams.Encode()), nil, &listParams.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants?%s", queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +158,7 @@ func (c Client) ListTenantsForUser(userId string, listParams *warrant.ListTenant
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/tenants?%s", userId, queryParams.Encode()), nil, &listParams.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/tenants?%s", userId, queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,7 @@ func getClient() Client {
 	}
 
 	return Client{
-		&warrant.WarrantClient{
+		&warrant.ApiClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},

--- a/tenant/client.go
+++ b/tenant/client.go
@@ -8,17 +8,15 @@ import (
 
 	"github.com/google/go-querystring/query"
 	"github.com/warrant-dev/warrant-go/v4"
-	"github.com/warrant-dev/warrant-go/v4/client"
-	"github.com/warrant-dev/warrant-go/v4/config"
 )
 
 type Client struct {
-	warrantClient *client.WarrantClient
+	warrantClient *warrant.WarrantClient
 }
 
-func NewClient(config config.ClientConfig) Client {
+func NewClient(config warrant.ClientConfig) Client {
 	return Client{
-		warrantClient: &client.WarrantClient{
+		warrantClient: &warrant.WarrantClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},
@@ -32,12 +30,12 @@ func (c Client) Create(params *warrant.TenantParams) (*warrant.Tenant, error) {
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var newTenant warrant.Tenant
 	err = json.Unmarshal([]byte(body), &newTenant)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return &newTenant, nil
 }
@@ -53,12 +51,12 @@ func (c Client) BatchCreate(params []warrant.TenantParams) ([]warrant.Tenant, er
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var createdTenants []warrant.Tenant
 	err = json.Unmarshal([]byte(body), &createdTenants)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return createdTenants, nil
 }
@@ -74,12 +72,12 @@ func (c Client) Get(tenantId string) (*warrant.Tenant, error) {
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var foundTenant warrant.Tenant
 	err = json.Unmarshal([]byte(body), &foundTenant)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return &foundTenant, nil
 }
@@ -95,12 +93,12 @@ func (c Client) Update(tenantId string, params *warrant.TenantParams) (*warrant.
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var updatedTenant warrant.Tenant
 	err = json.Unmarshal([]byte(body), &updatedTenant)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return &updatedTenant, nil
 }
@@ -117,7 +115,7 @@ func (c Client) Delete(tenantId string) error {
 	respStatus := resp.StatusCode
 	if respStatus < 200 || respStatus >= 400 {
 		msg, _ := io.ReadAll(resp.Body)
-		return client.Error{
+		return warrant.Error{
 			Message: fmt.Sprintf("HTTP %d %s", respStatus, string(msg)),
 		}
 	}
@@ -131,7 +129,7 @@ func Delete(tenantId string) error {
 func (c Client) ListTenants(listParams *warrant.ListTenantParams) ([]warrant.Tenant, error) {
 	queryParams, err := query.Values(listParams)
 	if err != nil {
-		return nil, client.WrapError("Could not parse listParams", err)
+		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
 	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants?%s", queryParams.Encode()), nil)
@@ -140,12 +138,12 @@ func (c Client) ListTenants(listParams *warrant.ListTenantParams) ([]warrant.Ten
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var tenants []warrant.Tenant
 	err = json.Unmarshal([]byte(body), &tenants)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return tenants, nil
 }
@@ -157,7 +155,7 @@ func ListTenants(listParams *warrant.ListTenantParams) ([]warrant.Tenant, error)
 func (c Client) ListTenantsForUser(userId string, listParams *warrant.ListTenantParams) ([]warrant.Tenant, error) {
 	queryParams, err := query.Values(listParams)
 	if err != nil {
-		return nil, client.WrapError("Could not parse listParams", err)
+		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
 	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/tenants?%s", userId, queryParams.Encode()), nil)
@@ -166,12 +164,12 @@ func (c Client) ListTenantsForUser(userId string, listParams *warrant.ListTenant
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var tenants []warrant.Tenant
 	err = json.Unmarshal([]byte(body), &tenants)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return tenants, nil
 }
@@ -181,7 +179,7 @@ func ListTenantsForUser(userId string, listParams *warrant.ListTenantParams) ([]
 }
 
 func getClient() Client {
-	config := config.ClientConfig{
+	config := warrant.ClientConfig{
 		ApiKey:                  warrant.ApiKey,
 		ApiEndpoint:             warrant.ApiEndpoint,
 		AuthorizeEndpoint:       warrant.AuthorizeEndpoint,
@@ -189,7 +187,7 @@ func getClient() Client {
 	}
 
 	return Client{
-		&client.WarrantClient{
+		&warrant.WarrantClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},

--- a/tenant/client.go
+++ b/tenant/client.go
@@ -24,7 +24,7 @@ func NewClient(config warrant.ClientConfig) Client {
 }
 
 func (c Client) Create(params *warrant.TenantParams) (*warrant.Tenant, error) {
-	resp, err := c.warrantClient.MakeRequest("POST", "/v1/tenants", params)
+	resp, err := c.warrantClient.MakeRequest("POST", "/v1/tenants", params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func Create(params *warrant.TenantParams) (*warrant.Tenant, error) {
 }
 
 func (c Client) BatchCreate(params []warrant.TenantParams) ([]warrant.Tenant, error) {
-	resp, err := c.warrantClient.MakeRequest("POST", "/v1/tenants", params)
+	resp, err := c.warrantClient.MakeRequest("POST", "/v1/tenants", params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -65,8 +65,8 @@ func BatchCreate(params []warrant.TenantParams) ([]warrant.Tenant, error) {
 	return getClient().BatchCreate(params)
 }
 
-func (c Client) Get(tenantId string) (*warrant.Tenant, error) {
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants/%s", tenantId), nil)
+func (c Client) Get(tenantId string, params *warrant.TenantParams) (*warrant.Tenant, error) {
+	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants/%s", tenantId), nil, &params.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -82,12 +82,12 @@ func (c Client) Get(tenantId string) (*warrant.Tenant, error) {
 	return &foundTenant, nil
 }
 
-func Get(tenantId string) (*warrant.Tenant, error) {
-	return getClient().Get(tenantId)
+func Get(tenantId string, params *warrant.TenantParams) (*warrant.Tenant, error) {
+	return getClient().Get(tenantId, params)
 }
 
 func (c Client) Update(tenantId string, params *warrant.TenantParams) (*warrant.Tenant, error) {
-	resp, err := c.warrantClient.MakeRequest("PUT", fmt.Sprintf("/v1/tenants/%s", tenantId), params)
+	resp, err := c.warrantClient.MakeRequest("PUT", fmt.Sprintf("/v1/tenants/%s", tenantId), params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func Update(tenantId string, params *warrant.TenantParams) (*warrant.Tenant, err
 }
 
 func (c Client) Delete(tenantId string) error {
-	resp, err := c.warrantClient.MakeRequest("DELETE", fmt.Sprintf("/v1/tenants/%s", tenantId), nil)
+	resp, err := c.warrantClient.MakeRequest("DELETE", fmt.Sprintf("/v1/tenants/%s", tenantId), nil, &warrant.RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -132,7 +132,7 @@ func (c Client) ListTenants(listParams *warrant.ListTenantParams) ([]warrant.Ten
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants?%s", queryParams.Encode()), nil)
+	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants?%s", queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +158,7 @@ func (c Client) ListTenantsForUser(userId string, listParams *warrant.ListTenant
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/tenants?%s", userId, queryParams.Encode()), nil)
+	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/tenants?%s", userId, queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/tenant/client.go
+++ b/tenant/client.go
@@ -184,11 +184,12 @@ func getClient() Client {
 		ApiEndpoint:             warrant.ApiEndpoint,
 		AuthorizeEndpoint:       warrant.AuthorizeEndpoint,
 		SelfServiceDashEndpoint: warrant.SelfServiceDashEndpoint,
+		HttpClient:              warrant.HttpClient,
 	}
 
 	return Client{
 		&warrant.ApiClient{
-			HttpClient: http.DefaultClient,
+			HttpClient: warrant.HttpClient,
 			Config:     config,
 		},
 	}

--- a/user.go
+++ b/user.go
@@ -20,6 +20,7 @@ type ListUserParams struct {
 }
 
 type UserParams struct {
+	RequestOptions
 	UserId string `json:"userId,omitempty"`
 	Email  string `json:"email,omitempty"`
 }

--- a/user/client.go
+++ b/user/client.go
@@ -8,17 +8,15 @@ import (
 
 	"github.com/google/go-querystring/query"
 	"github.com/warrant-dev/warrant-go/v4"
-	"github.com/warrant-dev/warrant-go/v4/client"
-	"github.com/warrant-dev/warrant-go/v4/config"
 )
 
 type Client struct {
-	warrantClient *client.WarrantClient
+	warrantClient *warrant.WarrantClient
 }
 
-func NewClient(config config.ClientConfig) Client {
+func NewClient(config warrant.ClientConfig) Client {
 	return Client{
-		warrantClient: &client.WarrantClient{
+		warrantClient: &warrant.WarrantClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},
@@ -32,12 +30,12 @@ func (c Client) Create(params *warrant.UserParams) (*warrant.User, error) {
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var newUser warrant.User
 	err = json.Unmarshal([]byte(body), &newUser)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return &newUser, nil
 }
@@ -53,12 +51,12 @@ func (c Client) BatchCreate(params []warrant.UserParams) ([]warrant.User, error)
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var createdUsers []warrant.User
 	err = json.Unmarshal([]byte(body), &createdUsers)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return createdUsers, nil
 }
@@ -74,12 +72,12 @@ func (c Client) Get(userId string) (*warrant.User, error) {
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var foundUser warrant.User
 	err = json.Unmarshal([]byte(body), &foundUser)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return &foundUser, nil
 }
@@ -95,12 +93,12 @@ func (c Client) Update(userId string, params *warrant.UserParams) (*warrant.User
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var updatedUser warrant.User
 	err = json.Unmarshal([]byte(body), &updatedUser)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return &updatedUser, nil
 }
@@ -124,7 +122,7 @@ func Delete(userId string) error {
 func (c Client) ListUsers(listParams *warrant.ListUserParams) ([]warrant.User, error) {
 	queryParams, err := query.Values(listParams)
 	if err != nil {
-		return nil, client.WrapError("Could not parse listParams", err)
+		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
 	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users?%s", queryParams.Encode()), nil)
@@ -133,12 +131,12 @@ func (c Client) ListUsers(listParams *warrant.ListUserParams) ([]warrant.User, e
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var users []warrant.User
 	err = json.Unmarshal([]byte(body), &users)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return users, nil
 }
@@ -150,7 +148,7 @@ func ListUsers(listParams *warrant.ListUserParams) ([]warrant.User, error) {
 func (c Client) ListUsersForTenant(tenantId string, listParams *warrant.ListUserParams) ([]warrant.User, error) {
 	queryParams, err := query.Values(listParams)
 	if err != nil {
-		return nil, client.WrapError("Could not parse listParams", err)
+		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
 	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants/%s/users?%s", tenantId, queryParams.Encode()), nil)
@@ -159,12 +157,12 @@ func (c Client) ListUsersForTenant(tenantId string, listParams *warrant.ListUser
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, client.WrapError("Error reading response", err)
+		return nil, warrant.WrapError("Error reading response", err)
 	}
 	var users []warrant.User
 	err = json.Unmarshal([]byte(body), &users)
 	if err != nil {
-		return nil, client.WrapError("Invalid response from server", err)
+		return nil, warrant.WrapError("Invalid response from server", err)
 	}
 	return users, nil
 }
@@ -206,7 +204,7 @@ func RemoveUserFromTenant(userId string, tenantId string, role string) error {
 }
 
 func getClient() Client {
-	config := config.ClientConfig{
+	config := warrant.ClientConfig{
 		ApiKey:                  warrant.ApiKey,
 		ApiEndpoint:             warrant.ApiEndpoint,
 		AuthorizeEndpoint:       warrant.AuthorizeEndpoint,
@@ -214,7 +212,7 @@ func getClient() Client {
 	}
 
 	return Client{
-		&client.WarrantClient{
+		&warrant.WarrantClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},

--- a/user/client.go
+++ b/user/client.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 
 	"github.com/google/go-querystring/query"
 	"github.com/warrant-dev/warrant-go/v5"
@@ -16,10 +15,7 @@ type Client struct {
 
 func NewClient(config warrant.ClientConfig) Client {
 	return Client{
-		apiClient: &warrant.ApiClient{
-			HttpClient: http.DefaultClient,
-			Config:     config,
-		},
+		apiClient: warrant.NewApiClient(config),
 	}
 }
 

--- a/user/client.go
+++ b/user/client.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 
 	"github.com/google/go-querystring/query"
-	"github.com/warrant-dev/warrant-go/v4"
+	"github.com/warrant-dev/warrant-go/v5"
 )
 
 type Client struct {

--- a/user/client.go
+++ b/user/client.go
@@ -11,12 +11,12 @@ import (
 )
 
 type Client struct {
-	warrantClient *warrant.WarrantClient
+	apiClient *warrant.ApiClient
 }
 
 func NewClient(config warrant.ClientConfig) Client {
 	return Client{
-		warrantClient: &warrant.WarrantClient{
+		apiClient: &warrant.ApiClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},
@@ -24,7 +24,7 @@ func NewClient(config warrant.ClientConfig) Client {
 }
 
 func (c Client) Create(params *warrant.UserParams) (*warrant.User, error) {
-	resp, err := c.warrantClient.MakeRequest("POST", "/v1/users", params, &warrant.RequestOptions{})
+	resp, err := c.apiClient.MakeRequest("POST", "/v1/users", params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func Create(params *warrant.UserParams) (*warrant.User, error) {
 }
 
 func (c Client) BatchCreate(params []warrant.UserParams) ([]warrant.User, error) {
-	resp, err := c.warrantClient.MakeRequest("POST", "/v1/users", params, &warrant.RequestOptions{})
+	resp, err := c.apiClient.MakeRequest("POST", "/v1/users", params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func BatchCreate(params []warrant.UserParams) ([]warrant.User, error) {
 }
 
 func (c Client) Get(userId string, params *warrant.UserParams) (*warrant.User, error) {
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s", userId), nil, &params.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s", userId), nil, &params.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func Get(userId string, params *warrant.UserParams) (*warrant.User, error) {
 }
 
 func (c Client) Update(userId string, params *warrant.UserParams) (*warrant.User, error) {
-	resp, err := c.warrantClient.MakeRequest("PUT", fmt.Sprintf("/v1/users/%s", userId), params, &warrant.RequestOptions{})
+	resp, err := c.apiClient.MakeRequest("PUT", fmt.Sprintf("/v1/users/%s", userId), params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func Update(userId string, params *warrant.UserParams) (*warrant.User, error) {
 }
 
 func (c Client) Delete(userId string) error {
-	_, err := c.warrantClient.MakeRequest("DELETE", fmt.Sprintf("/v1/users/%s", userId), nil, &warrant.RequestOptions{})
+	_, err := c.apiClient.MakeRequest("DELETE", fmt.Sprintf("/v1/users/%s", userId), nil, &warrant.RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -125,7 +125,7 @@ func (c Client) ListUsers(listParams *warrant.ListUserParams) ([]warrant.User, e
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users?%s", queryParams.Encode()), nil, &listParams.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/users?%s", queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ func (c Client) ListUsersForTenant(tenantId string, listParams *warrant.ListUser
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants/%s/users?%s", tenantId, queryParams.Encode()), nil, &listParams.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants/%s/users?%s", tenantId, queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +212,7 @@ func getClient() Client {
 	}
 
 	return Client{
-		&warrant.WarrantClient{
+		&warrant.ApiClient{
 			HttpClient: http.DefaultClient,
 			Config:     config,
 		},

--- a/user/client.go
+++ b/user/client.go
@@ -24,7 +24,7 @@ func NewClient(config warrant.ClientConfig) Client {
 }
 
 func (c Client) Create(params *warrant.UserParams) (*warrant.User, error) {
-	resp, err := c.warrantClient.MakeRequest("POST", "/v1/users", params)
+	resp, err := c.warrantClient.MakeRequest("POST", "/v1/users", params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func Create(params *warrant.UserParams) (*warrant.User, error) {
 }
 
 func (c Client) BatchCreate(params []warrant.UserParams) ([]warrant.User, error) {
-	resp, err := c.warrantClient.MakeRequest("POST", "/v1/users", params)
+	resp, err := c.warrantClient.MakeRequest("POST", "/v1/users", params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -65,8 +65,8 @@ func BatchCreate(params []warrant.UserParams) ([]warrant.User, error) {
 	return getClient().BatchCreate(params)
 }
 
-func (c Client) Get(userId string) (*warrant.User, error) {
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s", userId), nil)
+func (c Client) Get(userId string, params *warrant.UserParams) (*warrant.User, error) {
+	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s", userId), nil, &params.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -82,12 +82,12 @@ func (c Client) Get(userId string) (*warrant.User, error) {
 	return &foundUser, nil
 }
 
-func Get(userId string) (*warrant.User, error) {
-	return getClient().Get(userId)
+func Get(userId string, params *warrant.UserParams) (*warrant.User, error) {
+	return getClient().Get(userId, params)
 }
 
 func (c Client) Update(userId string, params *warrant.UserParams) (*warrant.User, error) {
-	resp, err := c.warrantClient.MakeRequest("PUT", fmt.Sprintf("/v1/users/%s", userId), params)
+	resp, err := c.warrantClient.MakeRequest("PUT", fmt.Sprintf("/v1/users/%s", userId), params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func Update(userId string, params *warrant.UserParams) (*warrant.User, error) {
 }
 
 func (c Client) Delete(userId string) error {
-	_, err := c.warrantClient.MakeRequest("DELETE", fmt.Sprintf("/v1/users/%s", userId), nil)
+	_, err := c.warrantClient.MakeRequest("DELETE", fmt.Sprintf("/v1/users/%s", userId), nil, &warrant.RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -125,7 +125,7 @@ func (c Client) ListUsers(listParams *warrant.ListUserParams) ([]warrant.User, e
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users?%s", queryParams.Encode()), nil)
+	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/users?%s", queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ func (c Client) ListUsersForTenant(tenantId string, listParams *warrant.ListUser
 		return nil, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants/%s/users?%s", tenantId, queryParams.Encode()), nil)
+	resp, err := c.warrantClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants/%s/users?%s", tenantId, queryParams.Encode()), nil, &listParams.RequestOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/user/client.go
+++ b/user/client.go
@@ -209,11 +209,12 @@ func getClient() Client {
 		ApiEndpoint:             warrant.ApiEndpoint,
 		AuthorizeEndpoint:       warrant.AuthorizeEndpoint,
 		SelfServiceDashEndpoint: warrant.SelfServiceDashEndpoint,
+		HttpClient:              warrant.HttpClient,
 	}
 
 	return Client{
 		&warrant.ApiClient{
-			HttpClient: http.DefaultClient,
+			HttpClient: warrant.HttpClient,
 			Config:     config,
 		},
 	}

--- a/warrant.go
+++ b/warrant.go
@@ -82,11 +82,13 @@ func (warrantCheck WarrantCheck) MarshalJSON() ([]byte, error) {
 }
 
 type WarrantCheckParams struct {
+	RequestOptions
 	WarrantCheck WarrantCheck `json:"warrantCheck"`
 	Debug        bool         `json:"debug,omitempty"`
 }
 
 type WarrantCheckManyParams struct {
+	RequestOptions
 	Op       string         `json:"op"`
 	Warrants []WarrantCheck `json:"warrants"`
 	Debug    bool           `json:"debug,omitempty"`
@@ -98,6 +100,7 @@ type WarrantCheckResult struct {
 }
 
 type PermissionCheckParams struct {
+	RequestOptions
 	PermissionId string        `json:"permissionId"`
 	UserId       string        `json:"userId"`
 	Context      PolicyContext `json:"context,omitempty"`
@@ -105,6 +108,7 @@ type PermissionCheckParams struct {
 }
 
 type RoleCheckParams struct {
+	RequestOptions
 	RoleId  string        `json:"roleId"`
 	UserId  string        `json:"userId"`
 	Context PolicyContext `json:"context,omitempty"`
@@ -112,6 +116,7 @@ type RoleCheckParams struct {
 }
 
 type FeatureCheckParams struct {
+	RequestOptions
 	FeatureId string        `json:"featureId"`
 	Subject   Subject       `json:"subject"`
 	Context   PolicyContext `json:"context,omitempty"`
@@ -119,6 +124,7 @@ type FeatureCheckParams struct {
 }
 
 type AccessCheckRequest struct {
+	RequestOptions
 	Op       string         `json:"op"`
 	Warrants []WarrantCheck `json:"warrants"`
 	Debug    bool           `json:"debug,omitempty"`


### PR DESCRIPTION
This PR adds support for the `Warrant-Token` header for read requests, check, and query. By passing `latest` with the `Warrant-Token`, this allows for consistent reads. This fixes an issue where changes not be reflected in a read if it is made immediately after a write is made for the same object. More broadly, this PR adds support for configuration on a per-request basis as more options are required.