### PR TITLE
Add v2 api support

### DIFF
--- a/client.go
+++ b/client.go
@@ -37,8 +37,8 @@ func (c WarrantClient) Create(params *WarrantParams) (*Warrant, error) {
 	if err != nil {
 		return nil, WrapError("Invalid response from server", err)
 	}
-	wookie := resp.Header.Get("Warrant-Token")
-	createdWarrant.Wookie = wookie
+	warrantToken := resp.Header.Get("Warrant-Token")
+	createdWarrant.WarrantToken = warrantToken
 	return &createdWarrant, nil
 }
 
@@ -60,9 +60,9 @@ func (c WarrantClient) BatchCreate(params []WarrantParams) ([]Warrant, error) {
 	if err != nil {
 		return nil, WrapError("Invalid response from server", err)
 	}
-	wookie := resp.Header.Get("Warrant-Token")
+	warrantToken := resp.Header.Get("Warrant-Token")
 	for i := range createdWarrants {
-		createdWarrants[i].Wookie = wookie
+		createdWarrants[i].WarrantToken = warrantToken
 	}
 	return createdWarrants, nil
 }
@@ -76,8 +76,8 @@ func (c WarrantClient) Delete(params *WarrantParams) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	wookie := resp.Header.Get("Warrant-Token")
-	return wookie, nil
+	warrantToken := resp.Header.Get("Warrant-Token")
+	return warrantToken, nil
 }
 
 func Delete(params *WarrantParams) (string, error) {
@@ -89,8 +89,8 @@ func (c WarrantClient) BatchDelete(params []WarrantParams) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	wookie := resp.Header.Get("Warrant-Token")
-	return wookie, nil
+	warrantToken := resp.Header.Get("Warrant-Token")
+	return warrantToken, nil
 }
 
 func BatchDelete(params []WarrantParams) (string, error) {

--- a/client.go
+++ b/client.go
@@ -201,7 +201,7 @@ func CheckHasFeature(params *FeatureCheckParams) (bool, error) {
 }
 
 func (c WarrantClient) makeAuthorizeRequest(params *AccessCheckRequest) (*WarrantCheckResult, error) {
-	resp, err := c.apiClient.MakeRequest("POST", "/v2/authorize", params, &params.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("POST", "/v2/check", params, &params.RequestOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -37,6 +37,8 @@ func (c WarrantClient) Create(params *WarrantParams) (*Warrant, error) {
 	if err != nil {
 		return nil, WrapError("Invalid response from server", err)
 	}
+	wookie := resp.Header.Get("Warrant-Token")
+	createdWarrant.Wookie = wookie
 	return &createdWarrant, nil
 }
 
@@ -58,6 +60,10 @@ func (c WarrantClient) BatchCreate(params []WarrantParams) ([]Warrant, error) {
 	if err != nil {
 		return nil, WrapError("Invalid response from server", err)
 	}
+	wookie := resp.Header.Get("Warrant-Token")
+	for i := range createdWarrants {
+		createdWarrants[i].Wookie = wookie
+	}
 	return createdWarrants, nil
 }
 
@@ -65,27 +71,29 @@ func BatchCreate(params []WarrantParams) ([]Warrant, error) {
 	return getClient().BatchCreate(params)
 }
 
-func (c WarrantClient) Delete(params *WarrantParams) error {
-	_, err := c.apiClient.MakeRequest("DELETE", "/v2/warrants", params, &RequestOptions{})
+func (c WarrantClient) Delete(params *WarrantParams) (string, error) {
+	resp, err := c.apiClient.MakeRequest("DELETE", "/v2/warrants", params, &RequestOptions{})
 	if err != nil {
-		return err
+		return "", err
 	}
-	return nil
+	wookie := resp.Header.Get("Warrant-Token")
+	return wookie, nil
 }
 
-func Delete(params *WarrantParams) error {
+func Delete(params *WarrantParams) (string, error) {
 	return getClient().Delete(params)
 }
 
-func (c WarrantClient) BatchDelete(params []WarrantParams) error {
-	_, err := c.apiClient.MakeRequest("DELETE", "/v2/warrants", params, &RequestOptions{})
+func (c WarrantClient) BatchDelete(params []WarrantParams) (string, error) {
+	resp, err := c.apiClient.MakeRequest("DELETE", "/v2/warrants", params, &RequestOptions{})
 	if err != nil {
-		return err
+		return "", err
 	}
-	return nil
+	wookie := resp.Header.Get("Warrant-Token")
+	return wookie, nil
 }
 
-func BatchDelete(params []WarrantParams) error {
+func BatchDelete(params []WarrantParams) (string, error) {
 	return getClient().BatchDelete(params)
 }
 

--- a/client.go
+++ b/client.go
@@ -32,6 +32,7 @@ func (c WarrantClient) Create(params *WarrantParams) (*Warrant, error) {
 	if err != nil {
 		return nil, WrapError("Error reading response", err)
 	}
+	defer resp.Body.Close()
 	var createdWarrant Warrant
 	err = json.Unmarshal([]byte(body), &createdWarrant)
 	if err != nil {
@@ -55,6 +56,7 @@ func (c WarrantClient) BatchCreate(params []WarrantParams) ([]Warrant, error) {
 	if err != nil {
 		return nil, WrapError("Error reading response", err)
 	}
+	defer resp.Body.Close()
 	var createdWarrants []Warrant
 	err = json.Unmarshal([]byte(body), &createdWarrants)
 	if err != nil {
@@ -76,6 +78,7 @@ func (c WarrantClient) Delete(params *WarrantParams) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer resp.Body.Close()
 	warrantToken := resp.Header.Get("Warrant-Token")
 	return warrantToken, nil
 }
@@ -89,6 +92,7 @@ func (c WarrantClient) BatchDelete(params []WarrantParams) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer resp.Body.Close()
 	warrantToken := resp.Header.Get("Warrant-Token")
 	return warrantToken, nil
 }
@@ -112,6 +116,7 @@ func (c WarrantClient) Query(queryString string, params *QueryParams) (ListRespo
 	if err != nil {
 		return queryResponse, WrapError("Error reading response", err)
 	}
+	defer resp.Body.Close()
 	err = json.Unmarshal([]byte(body), &queryResponse)
 	if err != nil {
 		return queryResponse, WrapError("Invalid response from server", err)
@@ -251,6 +256,7 @@ func (c WarrantClient) makeAuthorizeRequest(params *AccessCheckRequest) (*Warran
 	if err != nil {
 		return nil, WrapError("Error reading response", err)
 	}
+	defer resp.Body.Close()
 	var result WarrantCheckResult
 	err = json.Unmarshal([]byte(body), &result)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -24,7 +24,7 @@ func NewClient(config ClientConfig) WarrantClient {
 }
 
 func (c WarrantClient) Create(params *WarrantParams) (*Warrant, error) {
-	resp, err := c.apiClient.MakeRequest("POST", "/v1/warrants", params, &RequestOptions{})
+	resp, err := c.apiClient.MakeRequest("POST", "/v2/warrants", params, &RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func Create(params *WarrantParams) (*Warrant, error) {
 }
 
 func (c WarrantClient) Delete(params *WarrantParams) error {
-	_, err := c.apiClient.MakeRequest("DELETE", "/v1/warrants", params, &RequestOptions{})
+	_, err := c.apiClient.MakeRequest("DELETE", "/v2/warrants", params, &RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -56,29 +56,29 @@ func Delete(params *WarrantParams) error {
 	return getClient().Delete(params)
 }
 
-func (c WarrantClient) Query(queryString string, params *QueryParams) (*QueryResponse, error) {
+func (c WarrantClient) Query(queryString string, params *QueryParams) (ListResponse[QueryResult], error) {
+	var queryResponse ListResponse[QueryResult]
 	queryParams, err := query.Values(params)
 	if err != nil {
-		return nil, WrapError("Could not parse params", err)
+		return queryResponse, WrapError("Could not parse params", err)
 	}
 
-	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/query?q=%s&%s", url.QueryEscape(queryString), queryParams.Encode()), nil, &params.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v2/query?q=%s&%s", url.QueryEscape(queryString), queryParams.Encode()), queryResponse, &params.RequestOptions)
 	if err != nil {
-		return nil, err
+		return queryResponse, err
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, WrapError("Error reading response", err)
+		return queryResponse, WrapError("Error reading response", err)
 	}
-	var queryResponse QueryResponse
 	err = json.Unmarshal([]byte(body), &queryResponse)
 	if err != nil {
-		return nil, WrapError("Invalid response from server", err)
+		return queryResponse, WrapError("Invalid response from server", err)
 	}
-	return &queryResponse, nil
+	return queryResponse, nil
 }
 
-func Query(queryString string, params *QueryParams) (*QueryResponse, error) {
+func Query(queryString string, params *QueryParams) (ListResponse[QueryResult], error) {
 	return getClient().Query(queryString, params)
 }
 

--- a/client.go
+++ b/client.go
@@ -44,6 +44,27 @@ func Create(params *WarrantParams) (*Warrant, error) {
 	return getClient().Create(params)
 }
 
+func (c WarrantClient) BatchCreate(params []WarrantParams) ([]Warrant, error) {
+	resp, err := c.apiClient.MakeRequest("POST", "/v2/warrants", params, &RequestOptions{})
+	if err != nil {
+		return nil, err
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, WrapError("Error reading response", err)
+	}
+	var createdWarrants []Warrant
+	err = json.Unmarshal([]byte(body), &createdWarrants)
+	if err != nil {
+		return nil, WrapError("Invalid response from server", err)
+	}
+	return createdWarrants, nil
+}
+
+func BatchCreate(params []WarrantParams) ([]Warrant, error) {
+	return getClient().BatchCreate(params)
+}
+
 func (c WarrantClient) Delete(params *WarrantParams) error {
 	_, err := c.apiClient.MakeRequest("DELETE", "/v2/warrants", params, &RequestOptions{})
 	if err != nil {
@@ -54,6 +75,18 @@ func (c WarrantClient) Delete(params *WarrantParams) error {
 
 func Delete(params *WarrantParams) error {
 	return getClient().Delete(params)
+}
+
+func (c WarrantClient) BatchDelete(params []WarrantParams) error {
+	_, err := c.apiClient.MakeRequest("DELETE", "/v2/warrants", params, &RequestOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func BatchDelete(params []WarrantParams) error {
+	return getClient().BatchDelete(params)
 }
 
 func (c WarrantClient) Query(queryString string, params *QueryParams) (ListResponse[QueryResult], error) {

--- a/examples/live_test.go
+++ b/examples/live_test.go
@@ -658,10 +658,11 @@ func TestMultiTenancy(t *testing.T) {
 	assert.Equal(1, len(tenant1UsersList.Results))
 	assert.Equal(user1.UserId, tenant1UsersList.Results[0].UserId)
 
-	err = user.RemoveUserFromTenant(user1.UserId, tenant1.TenantId, "member")
+	wookie, err := user.RemoveUserFromTenant(user1.UserId, tenant1.TenantId, "member")
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(wookie)
 
 	// Clean up
 	err = user.Delete(user1.UserId)
@@ -831,10 +832,11 @@ func TestRBAC(t *testing.T) {
 	assert.Equal("administrator", adminUserRolesList.Results[0].RoleId)
 
 	// Remove create-report permission -> admin role -> admin user
-	err = permission.RemovePermissionFromRole(createPermission.PermissionId, adminRole.RoleId)
+	wookie, err := permission.RemovePermissionFromRole(createPermission.PermissionId, adminRole.RoleId)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(wookie)
 
 	adminUserHasPermission, err = warrant.CheckUserHasPermission(&warrant.PermissionCheckParams{
 		RequestOptions: warrant.RequestOptions{
@@ -861,10 +863,11 @@ func TestRBAC(t *testing.T) {
 	}
 	assert.Equal(1, len(adminUserRolesList.Results))
 
-	err = role.RemoveRoleFromUser(adminRole.RoleId, adminUser.UserId)
+	wookie, err = role.RemoveRoleFromUser(adminRole.RoleId, adminUser.UserId)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(wookie)
 
 	adminUserRolesList, err = role.ListRolesForUser(adminUser.UserId, &warrant.ListRoleParams{
 		ListParams: warrant.ListParams{
@@ -938,10 +941,11 @@ func TestRBAC(t *testing.T) {
 	assert.Equal("view-report", viewerUserPermissionsList.Results[0].PermissionId)
 
 	// Remove view-report permission -> viewer user
-	err = permission.RemovePermissionFromUser(viewPermission.PermissionId, viewerUser.UserId)
+	wookie, err = permission.RemovePermissionFromUser(viewPermission.PermissionId, viewerUser.UserId)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(wookie)
 
 	viewerUserHasPermission, err = warrant.CheckUserHasPermission(&warrant.PermissionCheckParams{
 		RequestOptions: warrant.RequestOptions{
@@ -1111,10 +1115,11 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	assert.Equal(1, len(paidUserFeaturesList.Results))
 	assert.Equal("custom-feature", paidUserFeaturesList.Results[0].FeatureId)
 
-	err = feature.RemoveFeatureFromUser(customFeature.FeatureId, paidUser.UserId)
+	wookie, err := feature.RemoveFeatureFromUser(customFeature.FeatureId, paidUser.UserId)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(wookie)
 
 	paidUserHasFeature, err = warrant.CheckHasFeature(&warrant.FeatureCheckParams{
 		RequestOptions: warrant.RequestOptions{
@@ -1239,10 +1244,11 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	assert.Equal(1, len(freeUserTiersList.Results))
 	assert.Equal("free", freeUserTiersList.Results[0].PricingTierId)
 
-	err = feature.RemoveFeatureFromPricingTier(feature1.FeatureId, freeTier.PricingTierId)
+	wookie, err = feature.RemoveFeatureFromPricingTier(feature1.FeatureId, freeTier.PricingTierId)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(wookie)
 
 	freeUserHasFeature, err = warrant.CheckHasFeature(&warrant.FeatureCheckParams{
 		RequestOptions: warrant.RequestOptions{
@@ -1285,10 +1291,11 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	}
 	assert.Equal(1, len(freeUserTiersList.Results))
 
-	err = pricingtier.RemovePricingTierFromUser(freeTier.PricingTierId, freeUser.UserId)
+	wookie, err = pricingtier.RemovePricingTierFromUser(freeTier.PricingTierId, freeUser.UserId)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(wookie)
 
 	freeUserTiersList, err = pricingtier.ListPricingTiersForUser(freeUser.UserId, &warrant.ListPricingTierParams{
 		ListParams: warrant.ListParams{
@@ -1450,10 +1457,11 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	assert.Equal(1, len(paidTenantFeaturesList.Results))
 	assert.Equal("custom-feature", paidTenantFeaturesList.Results[0].FeatureId)
 
-	err = feature.RemoveFeatureFromTenant(customFeature.FeatureId, paidTenant.TenantId)
+	wookie, err := feature.RemoveFeatureFromTenant(customFeature.FeatureId, paidTenant.TenantId)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(wookie)
 
 	paidTenantHasFeature, err = warrant.CheckHasFeature(&warrant.FeatureCheckParams{
 		RequestOptions: warrant.RequestOptions{
@@ -1578,10 +1586,11 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	assert.Equal(1, len(freeTenantTiersList.Results))
 	assert.Equal("free", freeTenantTiersList.Results[0].PricingTierId)
 
-	err = feature.RemoveFeatureFromPricingTier(feature1.FeatureId, freeTier.PricingTierId)
+	wookie, err = feature.RemoveFeatureFromPricingTier(feature1.FeatureId, freeTier.PricingTierId)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(wookie)
 
 	freeTenantHasFeature, err = warrant.CheckHasFeature(&warrant.FeatureCheckParams{
 		RequestOptions: warrant.RequestOptions{
@@ -1624,10 +1633,11 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	}
 	assert.Equal(1, len(freeTenantTiersList.Results))
 
-	err = pricingtier.RemovePricingTierFromTenant(freeTier.PricingTierId, freeTenant.TenantId)
+	wookie, err = pricingtier.RemovePricingTierFromTenant(freeTier.PricingTierId, freeTenant.TenantId)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(wookie)
 
 	freeTenantTiersList, err = pricingtier.ListPricingTiersForTenant(freeTenant.TenantId, &warrant.ListPricingTierParams{
 		ListParams: warrant.ListParams{
@@ -1764,7 +1774,7 @@ func TestWarrants(t *testing.T) {
 	}
 	assert.False(checkResult)
 
-	_, err = warrant.Create(&warrant.WarrantParams{
+	newWarrant, err := warrant.Create(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypePermission,
 		ObjectId:   newPermission.PermissionId,
 		Relation:   "member",
@@ -1776,6 +1786,7 @@ func TestWarrants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(newWarrant.Wookie)
 
 	checkResult, err = warrant.Check(&warrant.WarrantCheckParams{
 		RequestOptions: warrant.RequestOptions{
@@ -1812,7 +1823,7 @@ func TestWarrants(t *testing.T) {
 	assert.Equal("Permission 1", queryResult.Results[0].Meta["name"])
 	assert.Equal("Permission with id 1", queryResult.Results[0].Meta["description"])
 
-	err = warrant.Delete(&warrant.WarrantParams{
+	wookie, err := warrant.Delete(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypePermission,
 		ObjectId:   newPermission.PermissionId,
 		Relation:   "member",
@@ -1824,6 +1835,7 @@ func TestWarrants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(wookie)
 
 	checkResult, err = warrant.Check(&warrant.WarrantCheckParams{
 		RequestOptions: warrant.RequestOptions{
@@ -1943,6 +1955,8 @@ func TestBatchWarrants(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Len(warrants, 2)
+	assert.NotNil(warrants[0].Wookie)
+	assert.NotNil(warrants[1].Wookie)
 
 	userHasPermission1, err = warrant.Check(&warrant.WarrantCheckParams{
 		RequestOptions: warrant.RequestOptions{
@@ -1974,7 +1988,7 @@ func TestBatchWarrants(t *testing.T) {
 	}
 	assert.True(userHasPermission2)
 
-	err = warrant.BatchDelete([]warrant.WarrantParams{
+	wookie, err := warrant.BatchDelete([]warrant.WarrantParams{
 		{
 			ObjectType: warrant.ObjectTypePermission,
 			ObjectId:   permission1.PermissionId,
@@ -1997,6 +2011,7 @@ func TestBatchWarrants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(wookie)
 
 	err = object.BatchDelete([]warrant.ObjectParams{
 		{ObjectType: warrant.ObjectTypePermission, ObjectId: permission1.PermissionId},
@@ -2089,7 +2104,7 @@ func TestWarrantPolicies(t *testing.T) {
 	assert.False(checkResult)
 
 	// Clean up
-	err = warrant.Delete(&warrant.WarrantParams{
+	wookie, err := warrant.Delete(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypePermission,
 		ObjectId:   newPermission.PermissionId,
 		Relation:   "member",
@@ -2102,6 +2117,7 @@ func TestWarrantPolicies(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(wookie)
 
 	err = user.Delete(newUser.UserId)
 	if err != nil {
@@ -2131,6 +2147,7 @@ func TestObjectTypes(t *testing.T) {
 	assert.Equal("new-type", newType.Type)
 	assert.NotNil(newType.Relations["relation-1"])
 	assert.Nil(newType.Relations["relation-2"])
+	assert.NotNil(newType.Wookie)
 
 	objType, err := objecttype.Get("new-type", &warrant.ObjectTypeParams{})
 	if err != nil {
@@ -2140,11 +2157,11 @@ func TestObjectTypes(t *testing.T) {
 	assert.Len(objType.Relations, 1)
 	assert.NotNil(objType.Relations["relation-1"])
 
-	types, err := objecttype.ListObjectTypes(&warrant.ListObjectTypeParams{})
+	typesList, err := objecttype.ListObjectTypes(&warrant.ListObjectTypeParams{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Len(types, 7)
+	assert.Len(typesList.Results, 7)
 
 	newRelations := make(map[string]interface{})
 	newRelations["relation-1"] = struct{}{}
@@ -2160,17 +2177,19 @@ func TestObjectTypes(t *testing.T) {
 	assert.Len(objType.Relations, 2)
 	assert.NotNil(objType.Relations["relation-1"])
 	assert.NotNil(objType.Relations["relation-2"])
+	assert.NotNil(objType.Wookie)
 
-	err = objecttype.Delete("new-type")
+	wookie, err := objecttype.Delete("new-type")
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(wookie)
 
-	types, err = objecttype.ListObjectTypes(&warrant.ListObjectTypeParams{})
+	typesList, err = objecttype.ListObjectTypes(&warrant.ListObjectTypeParams{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Len(types, 6)
+	assert.Len(typesList.Results, 6)
 }
 
 func TestObjects(t *testing.T) {

--- a/examples/live_test.go
+++ b/examples/live_test.go
@@ -32,11 +32,13 @@ func TestCrudUsers(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.NotNil(user1.UserId)
-	assert.Empty(user1.Email)
+	assert.Nil(user1.Meta)
 
 	user2, err := user.Create(&warrant.UserParams{
 		UserId: "some_id",
-		Email:  "test@email.com",
+		Meta: map[string]interface{}{
+			"email": "test@email.com",
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -48,10 +50,12 @@ func TestCrudUsers(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal(user2.UserId, refetchedUser.UserId)
-	assert.Equal(user2.Email, refetchedUser.Email)
+	assert.Equal(user2.Meta, refetchedUser.Meta)
 
 	user2, err = user.Update("some_id", &warrant.UserParams{
-		Email: "updated@email.com",
+		Meta: map[string]interface{}{
+			"email": "updated@email.com",
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -61,9 +65,9 @@ func TestCrudUsers(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal("some_id", refetchedUser.UserId)
-	assert.Equal("updated@email.com", refetchedUser.Email)
+	assert.Equal(map[string]interface{}{"email": "updated@email.com"}, refetchedUser.Meta)
 
-	users, err := user.ListUsers(&warrant.ListUserParams{
+	usersList, err := user.ListUsers(&warrant.ListUserParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -74,7 +78,7 @@ func TestCrudUsers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(2, len(users))
+	assert.Equal(2, len(usersList.Results))
 
 	err = user.Delete(user1.UserId)
 	if err != nil {
@@ -84,7 +88,7 @@ func TestCrudUsers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	users, err = user.ListUsers(&warrant.ListUserParams{
+	usersList, err = user.ListUsers(&warrant.ListUserParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -95,7 +99,7 @@ func TestCrudUsers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(users))
+	assert.Equal(0, len(usersList.Results))
 }
 
 func TestCrudTenants(t *testing.T) {
@@ -107,11 +111,13 @@ func TestCrudTenants(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.NotNil(tenant1.TenantId)
-	assert.Empty(tenant1.Name)
+	assert.Nil(tenant1.Meta)
 
 	tenant2, err := tenant.Create(&warrant.TenantParams{
 		TenantId: "some_tenant_id",
-		Name:     "new_name",
+		Meta: map[string]interface{}{
+			"name": "new_name",
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -123,10 +129,12 @@ func TestCrudTenants(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal(tenant2.TenantId, refetchedTenant.TenantId)
-	assert.Equal(tenant2.Name, refetchedTenant.Name)
+	assert.Equal(tenant2.Meta, refetchedTenant.Meta)
 
 	tenant2, err = tenant.Update("some_tenant_id", &warrant.TenantParams{
-		Name: "updated_name",
+		Meta: map[string]interface{}{
+			"name": "updated_name",
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -136,9 +144,9 @@ func TestCrudTenants(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal("some_tenant_id", refetchedTenant.TenantId)
-	assert.Equal("updated_name", refetchedTenant.Name)
+	assert.Equal(map[string]interface{}{"name": "updated_name"}, refetchedTenant.Meta)
 
-	tenants, err := tenant.ListTenants(&warrant.ListTenantParams{
+	tenantsList, err := tenant.ListTenants(&warrant.ListTenantParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -149,7 +157,7 @@ func TestCrudTenants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(2, len(tenants))
+	assert.Equal(2, len(tenantsList.Results))
 
 	err = tenant.Delete(tenant1.TenantId)
 	if err != nil {
@@ -159,7 +167,7 @@ func TestCrudTenants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tenants, err = tenant.ListTenants(&warrant.ListTenantParams{
+	tenantsList, err = tenant.ListTenants(&warrant.ListTenantParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -170,7 +178,7 @@ func TestCrudTenants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(tenants))
+	assert.Equal(0, len(tenantsList.Results))
 }
 
 func TestCrudRoles(t *testing.T) {
@@ -178,21 +186,27 @@ func TestCrudRoles(t *testing.T) {
 	assert := assert.New(t)
 
 	adminRole, err := role.Create(&warrant.RoleParams{
-		RoleId:      "admin",
-		Name:        "Admin",
-		Description: "The admin role",
+		RoleId: "admin",
+		Meta: map[string]interface{}{
+			"name":        "Admin",
+			"description": "The admin role",
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal("admin", adminRole.RoleId)
-	assert.Equal("Admin", adminRole.Name)
-	assert.Equal("The admin role", adminRole.Description)
+	assert.Equal(map[string]interface{}{
+		"name":        "Admin",
+		"description": "The admin role",
+	}, adminRole.Meta)
 
 	viewerRole, err := role.Create(&warrant.RoleParams{
-		RoleId:      "viewer",
-		Name:        "Viewer",
-		Description: "The viewer role",
+		RoleId: "viewer",
+		Meta: map[string]interface{}{
+			"name":        "Viewer",
+			"description": "The viewer role",
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -204,12 +218,13 @@ func TestCrudRoles(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal(viewerRole.RoleId, refetchedRole.RoleId)
-	assert.Equal(viewerRole.Name, refetchedRole.Name)
-	assert.Equal(viewerRole.Description, refetchedRole.Description)
+	assert.Equal(viewerRole.Meta, refetchedRole.Meta)
 
 	viewerRole, err = role.Update("viewer", &warrant.RoleParams{
-		Name:        "Viewer Updated",
-		Description: "Updated desc",
+		Meta: map[string]interface{}{
+			"name":        "Viewer Updated",
+			"description": "Updated desc",
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -219,10 +234,12 @@ func TestCrudRoles(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal("viewer", refetchedRole.RoleId)
-	assert.Equal("Viewer Updated", refetchedRole.Name)
-	assert.Equal("Updated desc", refetchedRole.Description)
+	assert.Equal(map[string]interface{}{
+		"name":        "Viewer Updated",
+		"description": "Updated desc",
+	}, refetchedRole.Meta)
 
-	roles, err := role.ListRoles(&warrant.ListRoleParams{
+	rolesList, err := role.ListRoles(&warrant.ListRoleParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -233,7 +250,7 @@ func TestCrudRoles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(2, len(roles))
+	assert.Equal(2, len(rolesList.Results))
 
 	err = role.Delete(adminRole.RoleId)
 	if err != nil {
@@ -243,7 +260,7 @@ func TestCrudRoles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	roles, err = role.ListRoles(&warrant.ListRoleParams{
+	rolesList, err = role.ListRoles(&warrant.ListRoleParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -254,7 +271,7 @@ func TestCrudRoles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(roles))
+	assert.Equal(0, len(rolesList.Results))
 }
 
 func TestCrudPermissions(t *testing.T) {
@@ -263,31 +280,41 @@ func TestCrudPermissions(t *testing.T) {
 
 	permission1, err := permission.Create(&warrant.PermissionParams{
 		PermissionId: "perm1",
-		Name:         "Permission 1",
-		Description:  "Permission with id 1",
+		Meta: map[string]interface{}{
+			"name":        "Permission 1",
+			"description": "Permission with id 1",
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal("perm1", permission1.PermissionId)
-	assert.Equal("Permission 1", permission1.Name)
-	assert.Equal("Permission with id 1", permission1.Description)
+	assert.Equal(map[string]interface{}{
+		"name":        "Permission 1",
+		"description": "Permission with id 1",
+	}, permission1.Meta)
 
 	permission2, err := permission.Create(&warrant.PermissionParams{
 		PermissionId: "perm2",
-		Name:         "Permission 2",
-		Description:  "Permission with id 2",
+		Meta: map[string]interface{}{
+			"name":        "Permission 2",
+			"description": "Permission with id 2",
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal("perm2", permission2.PermissionId)
-	assert.Equal("Permission 2", permission2.Name)
-	assert.Equal("Permission with id 2", permission2.Description)
+	assert.Equal(map[string]interface{}{
+		"name":        "Permission 2",
+		"description": "Permission with id 2",
+	}, permission2.Meta)
 
 	permission2, err = permission.Update("perm2", &warrant.PermissionParams{
-		Name:        "Permission 2 Updated",
-		Description: "Updated desc",
+		Meta: map[string]interface{}{
+			"name":        "Permission 2 Updated",
+			"description": "Updated desc",
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -299,10 +326,12 @@ func TestCrudPermissions(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal("perm2", refetchedPermission.PermissionId)
-	assert.Equal("Permission 2 Updated", refetchedPermission.Name)
-	assert.Equal("Updated desc", refetchedPermission.Description)
+	assert.Equal(map[string]interface{}{
+		"name":        "Permission 2 Updated",
+		"description": "Updated desc",
+	}, refetchedPermission.Meta)
 
-	permissions, err := permission.ListPermissions(&warrant.ListPermissionParams{
+	permissionsList, err := permission.ListPermissions(&warrant.ListPermissionParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -313,7 +342,7 @@ func TestCrudPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(2, len(permissions))
+	assert.Equal(2, len(permissionsList.Results))
 
 	err = permission.Delete(permission1.PermissionId)
 	if err != nil {
@@ -323,7 +352,7 @@ func TestCrudPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	permissions, err = permission.ListPermissions(&warrant.ListPermissionParams{
+	permissionsList, err = permission.ListPermissions(&warrant.ListPermissionParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -334,7 +363,7 @@ func TestCrudPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(permissions))
+	assert.Equal(0, len(permissionsList.Results))
 }
 
 func TestCrudFeatures(t *testing.T) {
@@ -351,6 +380,9 @@ func TestCrudFeatures(t *testing.T) {
 
 	feature2, err := feature.Create(&warrant.FeatureParams{
 		FeatureId: "feature-2",
+		Meta: map[string]interface{}{
+			"name": "Feature 2",
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -361,9 +393,25 @@ func TestCrudFeatures(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal("feature-2", refetchedFeature.FeatureId)
+	assert.Equal(feature2.FeatureId, refetchedFeature.FeatureId)
+	assert.Equal(feature2.Meta, refetchedFeature.Meta)
 
-	features, err := feature.ListFeatures(&warrant.ListFeatureParams{
+	feature2, err = feature.Update(feature2.FeatureId, &warrant.FeatureParams{
+		Meta: map[string]interface{}{
+			"name": "Updated Feature 2",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	refetchedFeature, err = feature.Get(feature2.FeatureId, fetchFeatureParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal("feature-2", refetchedFeature.FeatureId)
+	assert.Equal(map[string]interface{}{"name": "Updated Feature 2"}, refetchedFeature.Meta)
+
+	featuresList, err := feature.ListFeatures(&warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -374,7 +422,7 @@ func TestCrudFeatures(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(2, len(features))
+	assert.Equal(2, len(featuresList.Results))
 
 	err = feature.Delete(feature1.FeatureId)
 	if err != nil {
@@ -384,7 +432,7 @@ func TestCrudFeatures(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	features, err = feature.ListFeatures(&warrant.ListFeatureParams{
+	featuresList, err = feature.ListFeatures(&warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -395,7 +443,7 @@ func TestCrudFeatures(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(features))
+	assert.Equal(0, len(featuresList.Results))
 }
 
 func TestCrudPricingTiers(t *testing.T) {
@@ -412,6 +460,9 @@ func TestCrudPricingTiers(t *testing.T) {
 
 	tier2, err := pricingtier.Create(&warrant.PricingTierParams{
 		PricingTierId: "tier-2",
+		Meta: map[string]interface{}{
+			"name": "Tier 2",
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -423,8 +474,20 @@ func TestCrudPricingTiers(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal(tier2.PricingTierId, refetchedTier.PricingTierId)
+	assert.Equal(tier2.Meta, refetchedTier.Meta)
 
-	tiers, err := pricingtier.ListPricingTiers(&warrant.ListPricingTierParams{
+	tier2, err = pricingtier.Update(tier2.PricingTierId, &warrant.PricingTierParams{
+		Meta: map[string]interface{}{
+			"name": "Updated Tier 2",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal("tier-2", tier2.PricingTierId)
+	assert.Equal(map[string]interface{}{"name": "Updated Tier 2"}, tier2.Meta)
+
+	tiersList, err := pricingtier.ListPricingTiers(&warrant.ListPricingTierParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -435,7 +498,7 @@ func TestCrudPricingTiers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(2, len(tiers))
+	assert.Equal(2, len(tiersList.Results))
 
 	err = pricingtier.Delete(tier1.PricingTierId)
 	if err != nil {
@@ -445,7 +508,7 @@ func TestCrudPricingTiers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tiers, err = pricingtier.ListPricingTiers(&warrant.ListPricingTierParams{
+	tiersList, err = pricingtier.ListPricingTiers(&warrant.ListPricingTierParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -456,7 +519,7 @@ func TestCrudPricingTiers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(tiers))
+	assert.Equal(0, len(tiersList.Results))
 }
 
 func TestBatchCreateUsersAndTenants(t *testing.T) {
@@ -520,21 +583,25 @@ func TestMultiTenancy(t *testing.T) {
 	// Create tenants
 	tenant1, err := tenant.Create(&warrant.TenantParams{
 		TenantId: "tenant-1",
-		Name:     "Tenant 1",
+		Meta: map[string]interface{}{
+			"name": "Tenant 1",
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	tenant2, err := tenant.Create(&warrant.TenantParams{
 		TenantId: "tenant-2",
-		Name:     "Tenant 2",
+		Meta: map[string]interface{}{
+			"name": "Tenant 2",
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Assign user1 -> tenant1
-	user1Tenants, err := tenant.ListTenantsForUser(user1.UserId, &warrant.ListTenantParams{
+	user1TenantsList, err := tenant.ListTenantsForUser(user1.UserId, &warrant.ListTenantParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -545,8 +612,8 @@ func TestMultiTenancy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(user1Tenants))
-	tenant1Users, err := user.ListUsersForTenant(tenant1.TenantId, &warrant.ListUserParams{
+	assert.Equal(0, len(user1TenantsList.Results))
+	tenant1UsersList, err := user.ListUsersForTenant(tenant1.TenantId, &warrant.ListUserParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -557,14 +624,14 @@ func TestMultiTenancy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(tenant1Users))
+	assert.Equal(0, len(tenant1UsersList.Results))
 
 	_, err = user.AssignUserToTenant(user1.UserId, tenant1.TenantId, "member")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	user1Tenants, err = tenant.ListTenantsForUser(user1.UserId, &warrant.ListTenantParams{
+	user1TenantsList, err = tenant.ListTenantsForUser(user1.UserId, &warrant.ListTenantParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -575,9 +642,9 @@ func TestMultiTenancy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(1, len(user1Tenants))
-	assert.Equal("tenant-1", user1Tenants[0].TenantId)
-	tenant1Users, err = user.ListUsersForTenant(tenant1.TenantId, &warrant.ListUserParams{
+	assert.Equal(1, len(user1TenantsList.Results))
+	assert.Equal("tenant-1", user1TenantsList.Results[0].TenantId)
+	tenant1UsersList, err = user.ListUsersForTenant(tenant1.TenantId, &warrant.ListUserParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -588,8 +655,8 @@ func TestMultiTenancy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(1, len(tenant1Users))
-	assert.Equal(user1.UserId, tenant1Users[0].UserId)
+	assert.Equal(1, len(tenant1UsersList.Results))
+	assert.Equal(user1.UserId, tenant1UsersList.Results[0].UserId)
 
 	err = user.RemoveUserFromTenant(user1.UserId, tenant1.TenantId, "member")
 	if err != nil {
@@ -631,17 +698,21 @@ func TestRBAC(t *testing.T) {
 
 	// Create roles
 	adminRole, err := role.Create(&warrant.RoleParams{
-		RoleId:      "administrator",
-		Name:        "Administrator",
-		Description: "The admin role",
+		RoleId: "administrator",
+		Meta: map[string]interface{}{
+			"name":        "Administrator",
+			"description": "The admin role",
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	viewerRole, err := role.Create(&warrant.RoleParams{
-		RoleId:      "viewer",
-		Name:        "Viewer",
-		Description: "The viewer role",
+		RoleId: "viewer",
+		Meta: map[string]interface{}{
+			"name":        "Viewer",
+			"description": "The viewer role",
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -650,23 +721,27 @@ func TestRBAC(t *testing.T) {
 	// Create permissions
 	createPermission, err := permission.Create(&warrant.PermissionParams{
 		PermissionId: "create-report",
-		Name:         "Create Report",
-		Description:  "Permission to create reports",
+		Meta: map[string]interface{}{
+			"name":        "Create Report",
+			"description": "Permission to create reports",
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	viewPermission, err := permission.Create(&warrant.PermissionParams{
 		PermissionId: "view-report",
-		Name:         "View Report",
-		Description:  "Permission to view reports",
+		Meta: map[string]interface{}{
+			"name":        "View Report",
+			"description": "Permission to view reports",
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Admin user tests
-	adminUserRoles, err := role.ListRolesForUser(adminUser.UserId, &warrant.ListRoleParams{
+	adminUserRolesList, err := role.ListRolesForUser(adminUser.UserId, &warrant.ListRoleParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -677,9 +752,9 @@ func TestRBAC(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(adminUserRoles))
+	assert.Equal(0, len(adminUserRolesList.Results))
 
-	adminRolePermissions, err := permission.ListPermissionsForRole(adminRole.RoleId, &warrant.ListPermissionParams{
+	adminRolePermissionsList, err := permission.ListPermissionsForRole(adminRole.RoleId, &warrant.ListPermissionParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -690,7 +765,7 @@ func TestRBAC(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(adminRolePermissions))
+	assert.Equal(0, len(adminRolePermissionsList.Results))
 
 	adminUserHasPermission, err := warrant.CheckUserHasPermission(&warrant.PermissionCheckParams{
 		RequestOptions: warrant.RequestOptions{
@@ -715,7 +790,7 @@ func TestRBAC(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	adminRolePermissions, err = permission.ListPermissionsForRole(adminRole.RoleId, &warrant.ListPermissionParams{
+	adminRolePermissionsList, err = permission.ListPermissionsForRole(adminRole.RoleId, &warrant.ListPermissionParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -726,8 +801,8 @@ func TestRBAC(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(1, len(adminRolePermissions))
-	assert.Equal("create-report", adminRolePermissions[0].PermissionId)
+	assert.Equal(1, len(adminRolePermissionsList.Results))
+	assert.Equal("create-report", adminRolePermissionsList.Results[0].PermissionId)
 
 	adminUserHasPermission, err = warrant.CheckUserHasPermission(&warrant.PermissionCheckParams{
 		RequestOptions: warrant.RequestOptions{
@@ -741,7 +816,7 @@ func TestRBAC(t *testing.T) {
 	}
 	assert.True(adminUserHasPermission)
 
-	adminUserRoles, err = role.ListRolesForUser(adminUser.UserId, &warrant.ListRoleParams{
+	adminUserRolesList, err = role.ListRolesForUser(adminUser.UserId, &warrant.ListRoleParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -752,8 +827,8 @@ func TestRBAC(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(1, len(adminUserRoles))
-	assert.Equal("administrator", adminUserRoles[0].RoleId)
+	assert.Equal(1, len(adminUserRolesList.Results))
+	assert.Equal("administrator", adminUserRolesList.Results[0].RoleId)
 
 	// Remove create-report permission -> admin role -> admin user
 	err = permission.RemovePermissionFromRole(createPermission.PermissionId, adminRole.RoleId)
@@ -773,7 +848,7 @@ func TestRBAC(t *testing.T) {
 	}
 	assert.False(adminUserHasPermission)
 
-	adminUserRoles, err = role.ListRolesForUser(adminUser.UserId, &warrant.ListRoleParams{
+	adminUserRolesList, err = role.ListRolesForUser(adminUser.UserId, &warrant.ListRoleParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -784,14 +859,14 @@ func TestRBAC(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(1, len(adminUserRoles))
+	assert.Equal(1, len(adminUserRolesList.Results))
 
 	err = role.RemoveRoleFromUser(adminRole.RoleId, adminUser.UserId)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	adminUserRoles, err = role.ListRolesForUser(adminUser.UserId, &warrant.ListRoleParams{
+	adminUserRolesList, err = role.ListRolesForUser(adminUser.UserId, &warrant.ListRoleParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -802,7 +877,7 @@ func TestRBAC(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(adminUserRoles))
+	assert.Equal(0, len(adminUserRolesList.Results))
 
 	// Viewer user tests
 	viewerUserHasPermission, err := warrant.CheckUserHasPermission(&warrant.PermissionCheckParams{
@@ -817,7 +892,7 @@ func TestRBAC(t *testing.T) {
 	}
 	assert.False(viewerUserHasPermission)
 
-	viewerUserPermissions, err := permission.ListPermissionsForUser(viewerUser.UserId, &warrant.ListPermissionParams{
+	viewerUserPermissionsList, err := permission.ListPermissionsForUser(viewerUser.UserId, &warrant.ListPermissionParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -828,7 +903,7 @@ func TestRBAC(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(viewerUserPermissions))
+	assert.Equal(0, len(viewerUserPermissionsList.Results))
 
 	// Assign view-report permission -> viewer user
 	_, err = permission.AssignPermissionToUser(viewPermission.PermissionId, viewerUser.UserId)
@@ -848,7 +923,7 @@ func TestRBAC(t *testing.T) {
 	}
 	assert.True(viewerUserHasPermission)
 
-	viewerUserPermissions, err = permission.ListPermissionsForUser(viewerUser.UserId, &warrant.ListPermissionParams{
+	viewerUserPermissionsList, err = permission.ListPermissionsForUser(viewerUser.UserId, &warrant.ListPermissionParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -859,8 +934,8 @@ func TestRBAC(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(1, len(viewerUserPermissions))
-	assert.Equal("view-report", viewerUserPermissions[0].PermissionId)
+	assert.Equal(1, len(viewerUserPermissionsList.Results))
+	assert.Equal("view-report", viewerUserPermissionsList.Results[0].PermissionId)
 
 	// Remove view-report permission -> viewer user
 	err = permission.RemovePermissionFromUser(viewPermission.PermissionId, viewerUser.UserId)
@@ -880,7 +955,7 @@ func TestRBAC(t *testing.T) {
 	}
 	assert.False(viewerUserHasPermission)
 
-	viewerUserPermissions, err = permission.ListPermissionsForUser(viewerUser.UserId, &warrant.ListPermissionParams{
+	viewerUserPermissionsList, err = permission.ListPermissionsForUser(viewerUser.UserId, &warrant.ListPermissionParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -891,7 +966,7 @@ func TestRBAC(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(viewerUserPermissions))
+	assert.Equal(0, len(viewerUserPermissionsList.Results))
 
 	// Clean up
 	err = user.Delete(adminUser.UserId)
@@ -988,7 +1063,7 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	}
 	assert.False(paidUserHasFeature)
 
-	paidUserFeatures, err := feature.ListFeaturesForUser(paidUser.UserId, &warrant.ListFeatureParams{
+	paidUserFeaturesList, err := feature.ListFeaturesForUser(paidUser.UserId, &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -999,7 +1074,7 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(paidUserFeatures))
+	assert.Equal(0, len(paidUserFeaturesList.Results))
 
 	// Assign custom feature -> paid user
 	_, err = feature.AssignFeatureToUser(customFeature.FeatureId, paidUser.UserId)
@@ -1022,7 +1097,7 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	}
 	assert.True(paidUserHasFeature)
 
-	paidUserFeatures, err = feature.ListFeaturesForUser(paidUser.UserId, &warrant.ListFeatureParams{
+	paidUserFeaturesList, err = feature.ListFeaturesForUser(paidUser.UserId, &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -1033,8 +1108,8 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(1, len(paidUserFeatures))
-	assert.Equal("custom-feature", paidUserFeatures[0].FeatureId)
+	assert.Equal(1, len(paidUserFeaturesList.Results))
+	assert.Equal("custom-feature", paidUserFeaturesList.Results[0].FeatureId)
 
 	err = feature.RemoveFeatureFromUser(customFeature.FeatureId, paidUser.UserId)
 	if err != nil {
@@ -1056,7 +1131,7 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	}
 	assert.False(paidUserHasFeature)
 
-	paidUserFeatures, err = feature.ListFeaturesForUser(paidUser.UserId, &warrant.ListFeatureParams{
+	paidUserFeaturesList, err = feature.ListFeaturesForUser(paidUser.UserId, &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -1067,7 +1142,7 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(paidUserFeatures))
+	assert.Equal(0, len(paidUserFeaturesList.Results))
 
 	// Free user tests
 	freeUserHasFeature, err := warrant.CheckHasFeature(&warrant.FeatureCheckParams{
@@ -1085,7 +1160,7 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	}
 	assert.False(freeUserHasFeature)
 
-	freeTierFeatures, err := feature.ListFeaturesForPricingTier("free", &warrant.ListFeatureParams{
+	freeTierFeaturesList, err := feature.ListFeaturesForPricingTier("free", &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -1096,9 +1171,9 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(freeTierFeatures))
+	assert.Equal(0, len(freeTierFeaturesList.Results))
 
-	freeUserFeatures, err := feature.ListFeaturesForUser(freeUser.UserId, &warrant.ListFeatureParams{
+	freeUserFeaturesList, err := feature.ListFeaturesForUser(freeUser.UserId, &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -1109,7 +1184,7 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(freeUserFeatures))
+	assert.Equal(0, len(freeUserFeaturesList.Results))
 
 	// Assign feature-1 -> free tier -> free user
 	_, err = feature.AssignFeatureToPricingTier(feature1.FeatureId, freeTier.PricingTierId)
@@ -1137,7 +1212,7 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	}
 	assert.True(freeUserHasFeature)
 
-	freeTierFeatures, err = feature.ListFeaturesForPricingTier("free", &warrant.ListFeatureParams{
+	freeTierFeaturesList, err = feature.ListFeaturesForPricingTier("free", &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -1148,9 +1223,9 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(1, len(freeTierFeatures))
+	assert.Equal(1, len(freeTierFeaturesList.Results))
 
-	freeUserTiers, err := pricingtier.ListPricingTiersForUser(freeUser.UserId, &warrant.ListPricingTierParams{
+	freeUserTiersList, err := pricingtier.ListPricingTiersForUser(freeUser.UserId, &warrant.ListPricingTierParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -1161,8 +1236,8 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(1, len(freeUserTiers))
-	assert.Equal("free", freeUserTiers[0].PricingTierId)
+	assert.Equal(1, len(freeUserTiersList.Results))
+	assert.Equal("free", freeUserTiersList.Results[0].PricingTierId)
 
 	err = feature.RemoveFeatureFromPricingTier(feature1.FeatureId, freeTier.PricingTierId)
 	if err != nil {
@@ -1184,7 +1259,7 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	}
 	assert.False(freeUserHasFeature)
 
-	freeTierFeatures, err = feature.ListFeaturesForPricingTier("free", &warrant.ListFeatureParams{
+	freeTierFeaturesList, err = feature.ListFeaturesForPricingTier("free", &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -1195,9 +1270,9 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(freeTierFeatures))
+	assert.Equal(0, len(freeTierFeaturesList.Results))
 
-	freeUserTiers, err = pricingtier.ListPricingTiersForUser(freeUser.UserId, &warrant.ListPricingTierParams{
+	freeUserTiersList, err = pricingtier.ListPricingTiersForUser(freeUser.UserId, &warrant.ListPricingTierParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -1208,14 +1283,14 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(1, len(freeUserTiers))
+	assert.Equal(1, len(freeUserTiersList.Results))
 
 	err = pricingtier.RemovePricingTierFromUser(freeTier.PricingTierId, freeUser.UserId)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	freeUserTiers, err = pricingtier.ListPricingTiersForUser(freeUser.UserId, &warrant.ListPricingTierParams{
+	freeUserTiersList, err = pricingtier.ListPricingTiersForUser(freeUser.UserId, &warrant.ListPricingTierParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -1226,7 +1301,7 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(freeUserTiers))
+	assert.Equal(0, len(freeUserTiersList.Results))
 
 	// Clean up
 	err = user.Delete(freeUser.UserId)
@@ -1327,7 +1402,7 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	}
 	assert.False(paidTenantHasFeature)
 
-	paidTenantFeatures, err := feature.ListFeaturesForTenant(paidTenant.TenantId, &warrant.ListFeatureParams{
+	paidTenantFeaturesList, err := feature.ListFeaturesForTenant(paidTenant.TenantId, &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -1338,7 +1413,7 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(paidTenantFeatures))
+	assert.Equal(0, len(paidTenantFeaturesList.Results))
 
 	// Assign custom feature -> paid tenant
 	_, err = feature.AssignFeatureToTenant(customFeature.FeatureId, paidTenant.TenantId)
@@ -1361,7 +1436,7 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	}
 	assert.True(paidTenantHasFeature)
 
-	paidTenantFeatures, err = feature.ListFeaturesForTenant(paidTenant.TenantId, &warrant.ListFeatureParams{
+	paidTenantFeaturesList, err = feature.ListFeaturesForTenant(paidTenant.TenantId, &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -1372,8 +1447,8 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(1, len(paidTenantFeatures))
-	assert.Equal("custom-feature", paidTenantFeatures[0].FeatureId)
+	assert.Equal(1, len(paidTenantFeaturesList.Results))
+	assert.Equal("custom-feature", paidTenantFeaturesList.Results[0].FeatureId)
 
 	err = feature.RemoveFeatureFromTenant(customFeature.FeatureId, paidTenant.TenantId)
 	if err != nil {
@@ -1395,7 +1470,7 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	}
 	assert.False(paidTenantHasFeature)
 
-	paidTenantFeatures, err = feature.ListFeaturesForTenant(paidTenant.TenantId, &warrant.ListFeatureParams{
+	paidTenantFeaturesList, err = feature.ListFeaturesForTenant(paidTenant.TenantId, &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -1406,7 +1481,7 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(paidTenantFeatures))
+	assert.Equal(0, len(paidTenantFeaturesList.Results))
 
 	// Free tenant tests
 	freeTenantHasFeature, err := warrant.CheckHasFeature(&warrant.FeatureCheckParams{
@@ -1424,7 +1499,7 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	}
 	assert.False(freeTenantHasFeature)
 
-	freeTierFeatures, err := feature.ListFeaturesForPricingTier("free", &warrant.ListFeatureParams{
+	freeTierFeaturesList, err := feature.ListFeaturesForPricingTier("free", &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -1435,9 +1510,9 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(freeTierFeatures))
+	assert.Equal(0, len(freeTierFeaturesList.Results))
 
-	freeTenantFeatures, err := feature.ListFeaturesForTenant(freeTenant.TenantId, &warrant.ListFeatureParams{
+	freeTenantFeaturesList, err := feature.ListFeaturesForTenant(freeTenant.TenantId, &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -1448,7 +1523,7 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(freeTenantFeatures))
+	assert.Equal(0, len(freeTenantFeaturesList.Results))
 
 	// Assign feature-1 -> free tier -> free tenant
 	_, err = feature.AssignFeatureToPricingTier(feature1.FeatureId, freeTier.PricingTierId)
@@ -1476,7 +1551,7 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	}
 	assert.True(freeTenantHasFeature)
 
-	freeTierFeatures, err = feature.ListFeaturesForPricingTier("free", &warrant.ListFeatureParams{
+	freeTierFeaturesList, err = feature.ListFeaturesForPricingTier("free", &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -1487,9 +1562,9 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(1, len(freeTierFeatures))
+	assert.Equal(1, len(freeTierFeaturesList.Results))
 
-	freeTenantTiers, err := pricingtier.ListPricingTiersForTenant(freeTenant.TenantId, &warrant.ListPricingTierParams{
+	freeTenantTiersList, err := pricingtier.ListPricingTiersForTenant(freeTenant.TenantId, &warrant.ListPricingTierParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -1500,8 +1575,8 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(1, len(freeTenantTiers))
-	assert.Equal("free", freeTenantTiers[0].PricingTierId)
+	assert.Equal(1, len(freeTenantTiersList.Results))
+	assert.Equal("free", freeTenantTiersList.Results[0].PricingTierId)
 
 	err = feature.RemoveFeatureFromPricingTier(feature1.FeatureId, freeTier.PricingTierId)
 	if err != nil {
@@ -1523,7 +1598,7 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	}
 	assert.False(freeTenantHasFeature)
 
-	freeTierFeatures, err = feature.ListFeaturesForPricingTier("free", &warrant.ListFeatureParams{
+	freeTierFeaturesList, err = feature.ListFeaturesForPricingTier("free", &warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -1534,9 +1609,9 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(freeTierFeatures))
+	assert.Equal(0, len(freeTierFeaturesList.Results))
 
-	freeTenantTiers, err = pricingtier.ListPricingTiersForTenant(freeTenant.TenantId, &warrant.ListPricingTierParams{
+	freeTenantTiersList, err = pricingtier.ListPricingTiersForTenant(freeTenant.TenantId, &warrant.ListPricingTierParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -1547,14 +1622,14 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(1, len(freeTenantTiers))
+	assert.Equal(1, len(freeTenantTiersList.Results))
 
 	err = pricingtier.RemovePricingTierFromTenant(freeTier.PricingTierId, freeTenant.TenantId)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	freeTenantTiers, err = pricingtier.ListPricingTiersForTenant(freeTenant.TenantId, &warrant.ListPricingTierParams{
+	freeTenantTiersList, err = pricingtier.ListPricingTiersForTenant(freeTenant.TenantId, &warrant.ListPricingTierParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
 				WarrantToken: "latest",
@@ -1565,7 +1640,7 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(0, len(freeTenantTiers))
+	assert.Equal(0, len(freeTenantTiersList.Results))
 
 	// Clean up
 	err = tenant.Delete(freeTenant.TenantId)
@@ -1659,8 +1734,10 @@ func TestWarrants(t *testing.T) {
 
 	newPermission, err := permission.Create(&warrant.PermissionParams{
 		PermissionId: "perm1",
-		Name:         "Permission 1",
-		Description:  "Permission with id 1",
+		Meta: map[string]interface{}{
+			"name":        "Permission 1",
+			"description": "Permission with id 1",
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1974,8 +2051,8 @@ func TestObjects(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Len(objectsList.Results, 1)
-	assert.Equal("role", objectsList.Results[0].GetObjectType())
-	assert.Equal("admin2", objectsList.Results[0].GetObjectId())
+	assert.Equal("role", objectsList.Results[0].ObjectType)
+	assert.Equal("admin2", objectsList.Results[0].ObjectId)
 
 	meta := make(map[string]interface{})
 	meta["name"] = "new name"
@@ -2030,13 +2107,13 @@ func TestBatchObjects(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Len(fetchedObjects.Results, 3)
-	assert.Equal("document", fetchedObjects.Results[0].GetObjectType())
-	assert.Equal("document-a", fetchedObjects.Results[0].GetObjectId())
-	assert.Equal("document", fetchedObjects.Results[1].GetObjectType())
-	assert.Equal("document-b", fetchedObjects.Results[1].GetObjectId())
-	assert.Equal("folder", fetchedObjects.Results[2].GetObjectType())
-	assert.Equal("resources", fetchedObjects.Results[2].GetObjectId())
-	assert.Equal(map[string]interface{}{"description": "Helpful documents"}, fetchedObjects.Results[2].GetMeta())
+	assert.Equal("document", fetchedObjects.Results[0].ObjectType)
+	assert.Equal("document-a", fetchedObjects.Results[0].ObjectId)
+	assert.Equal("document", fetchedObjects.Results[1].ObjectType)
+	assert.Equal("document-b", fetchedObjects.Results[1].ObjectId)
+	assert.Equal("folder", fetchedObjects.Results[2].ObjectType)
+	assert.Equal("resources", fetchedObjects.Results[2].ObjectId)
+	assert.Equal(map[string]interface{}{"description": "Helpful documents"}, fetchedObjects.Results[2].Meta)
 
 	fetchedObjects, err = object.ListObjects(&warrant.ListObjectParams{
 		ListParams: warrant.ListParams{
@@ -2051,9 +2128,9 @@ func TestBatchObjects(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Len(fetchedObjects.Results, 1)
-	assert.Equal("folder", fetchedObjects.Results[0].GetObjectType())
-	assert.Equal("resources", fetchedObjects.Results[0].GetObjectId())
-	assert.Equal(map[string]interface{}{"description": "Helpful documents"}, fetchedObjects.Results[0].GetMeta())
+	assert.Equal("folder", fetchedObjects.Results[0].ObjectType)
+	assert.Equal("resources", fetchedObjects.Results[0].ObjectId)
+	assert.Equal(map[string]interface{}{"description": "Helpful documents"}, fetchedObjects.Results[0].Meta)
 
 	err = object.BatchDelete([]warrant.ObjectParams{
 		{ObjectType: "document", ObjectId: "document-a"},

--- a/examples/live_test.go
+++ b/examples/live_test.go
@@ -80,11 +80,12 @@ func TestCrudUsers(t *testing.T) {
 	}
 	assert.Equal(2, len(usersList.Results))
 
-	err = user.Delete(user1.UserId)
+	warrantToken, err := user.Delete(user1.UserId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = user.Delete(user2.UserId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = user.Delete(user2.UserId)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,14 +160,16 @@ func TestCrudTenants(t *testing.T) {
 	}
 	assert.Equal(2, len(tenantsList.Results))
 
-	err = tenant.Delete(tenant1.TenantId)
+	warrantToken, err := tenant.Delete(tenant1.TenantId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = tenant.Delete(tenant2.TenantId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = tenant.Delete(tenant2.TenantId)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(warrantToken)
 	tenantsList, err = tenant.ListTenants(&warrant.ListTenantParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
@@ -252,14 +255,16 @@ func TestCrudRoles(t *testing.T) {
 	}
 	assert.Equal(2, len(rolesList.Results))
 
-	err = role.Delete(adminRole.RoleId)
+	warrantToken, err := role.Delete(adminRole.RoleId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = role.Delete(viewerRole.RoleId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = role.Delete(viewerRole.RoleId)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(warrantToken)
 	rolesList, err = role.ListRoles(&warrant.ListRoleParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
@@ -344,14 +349,16 @@ func TestCrudPermissions(t *testing.T) {
 	}
 	assert.Equal(2, len(permissionsList.Results))
 
-	err = permission.Delete(permission1.PermissionId)
+	warrantToken, err := permission.Delete(permission1.PermissionId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = permission.Delete(permission2.PermissionId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = permission.Delete(permission2.PermissionId)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(warrantToken)
 	permissionsList, err = permission.ListPermissions(&warrant.ListPermissionParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
@@ -424,14 +431,16 @@ func TestCrudFeatures(t *testing.T) {
 	}
 	assert.Equal(2, len(featuresList.Results))
 
-	err = feature.Delete(feature1.FeatureId)
+	warrantToken, err := feature.Delete(feature1.FeatureId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = feature.Delete(feature2.FeatureId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = feature.Delete(feature2.FeatureId)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(warrantToken)
 	featuresList, err = feature.ListFeatures(&warrant.ListFeatureParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
@@ -500,14 +509,16 @@ func TestCrudPricingTiers(t *testing.T) {
 	}
 	assert.Equal(2, len(tiersList.Results))
 
-	err = pricingtier.Delete(tier1.PricingTierId)
+	warrantToken, err := pricingtier.Delete(tier1.PricingTierId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = pricingtier.Delete(tier2.PricingTierId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = pricingtier.Delete(tier2.PricingTierId)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(warrantToken)
 	tiersList, err = pricingtier.ListPricingTiers(&warrant.ListPricingTierParams{
 		ListParams: warrant.ListParams{
 			RequestOptions: warrant.RequestOptions{
@@ -548,22 +559,26 @@ func TestBatchCreateUsersAndTenants(t *testing.T) {
 	assert.Equal("tenant-1", createdTenants[0].TenantId)
 	assert.Equal("tenant-2", createdTenants[1].TenantId)
 
-	err = user.Delete("user-1")
+	warrantToken, err := user.Delete("user-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = user.Delete("user-2")
+	assert.NotNil(warrantToken)
+	warrantToken, err = user.Delete("user-2")
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = tenant.Delete("tenant-1")
+	assert.NotNil(warrantToken)
+	warrantToken, err = tenant.Delete("tenant-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = tenant.Delete("tenant-2")
+	assert.NotNil(warrantToken)
+	warrantToken, err = tenant.Delete("tenant-2")
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(warrantToken)
 }
 
 func TestMultiTenancy(t *testing.T) {
@@ -658,29 +673,33 @@ func TestMultiTenancy(t *testing.T) {
 	assert.Equal(1, len(tenant1UsersList.Results))
 	assert.Equal(user1.UserId, tenant1UsersList.Results[0].UserId)
 
-	wookie, err := user.RemoveUserFromTenant(user1.UserId, tenant1.TenantId, "member")
+	warrantToken, err := user.RemoveUserFromTenant(user1.UserId, tenant1.TenantId, "member")
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotNil(wookie)
+	assert.NotNil(warrantToken)
 
 	// Clean up
-	err = user.Delete(user1.UserId)
+	warrantToken, err = user.Delete(user1.UserId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = user.Delete(user2.UserId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = user.Delete(user2.UserId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = tenant.Delete(tenant1.TenantId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = tenant.Delete(tenant1.TenantId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = tenant.Delete(tenant2.TenantId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = tenant.Delete(tenant2.TenantId)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(warrantToken)
 }
 
 func TestRBAC(t *testing.T) {
@@ -832,11 +851,11 @@ func TestRBAC(t *testing.T) {
 	assert.Equal("administrator", adminUserRolesList.Results[0].RoleId)
 
 	// Remove create-report permission -> admin role -> admin user
-	wookie, err := permission.RemovePermissionFromRole(createPermission.PermissionId, adminRole.RoleId)
+	warrantToken, err := permission.RemovePermissionFromRole(createPermission.PermissionId, adminRole.RoleId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotNil(wookie)
+	assert.NotNil(warrantToken)
 
 	adminUserHasPermission, err = warrant.CheckUserHasPermission(&warrant.PermissionCheckParams{
 		RequestOptions: warrant.RequestOptions{
@@ -863,11 +882,11 @@ func TestRBAC(t *testing.T) {
 	}
 	assert.Equal(1, len(adminUserRolesList.Results))
 
-	wookie, err = role.RemoveRoleFromUser(adminRole.RoleId, adminUser.UserId)
+	warrantToken, err = role.RemoveRoleFromUser(adminRole.RoleId, adminUser.UserId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotNil(wookie)
+	assert.NotNil(warrantToken)
 
 	adminUserRolesList, err = role.ListRolesForUser(adminUser.UserId, &warrant.ListRoleParams{
 		ListParams: warrant.ListParams{
@@ -941,11 +960,11 @@ func TestRBAC(t *testing.T) {
 	assert.Equal("view-report", viewerUserPermissionsList.Results[0].PermissionId)
 
 	// Remove view-report permission -> viewer user
-	wookie, err = permission.RemovePermissionFromUser(viewPermission.PermissionId, viewerUser.UserId)
+	warrantToken, err = permission.RemovePermissionFromUser(viewPermission.PermissionId, viewerUser.UserId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotNil(wookie)
+	assert.NotNil(warrantToken)
 
 	viewerUserHasPermission, err = warrant.CheckUserHasPermission(&warrant.PermissionCheckParams{
 		RequestOptions: warrant.RequestOptions{
@@ -973,30 +992,36 @@ func TestRBAC(t *testing.T) {
 	assert.Equal(0, len(viewerUserPermissionsList.Results))
 
 	// Clean up
-	err = user.Delete(adminUser.UserId)
+	warrantToken, err = user.Delete(adminUser.UserId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = user.Delete(viewerUser.UserId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = user.Delete(viewerUser.UserId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = role.Delete(adminRole.RoleId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = role.Delete(adminRole.RoleId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = role.Delete(viewerRole.RoleId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = role.Delete(viewerRole.RoleId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = permission.Delete(createPermission.PermissionId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = permission.Delete(createPermission.PermissionId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = permission.Delete(viewPermission.PermissionId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = permission.Delete(viewPermission.PermissionId)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(warrantToken)
 }
 
 func TestPricingTiersAndFeaturesUsers(t *testing.T) {
@@ -1115,11 +1140,11 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	assert.Equal(1, len(paidUserFeaturesList.Results))
 	assert.Equal("custom-feature", paidUserFeaturesList.Results[0].FeatureId)
 
-	wookie, err := feature.RemoveFeatureFromUser(customFeature.FeatureId, paidUser.UserId)
+	warrantToken, err := feature.RemoveFeatureFromUser(customFeature.FeatureId, paidUser.UserId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotNil(wookie)
+	assert.NotNil(warrantToken)
 
 	paidUserHasFeature, err = warrant.CheckHasFeature(&warrant.FeatureCheckParams{
 		RequestOptions: warrant.RequestOptions{
@@ -1244,11 +1269,11 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	assert.Equal(1, len(freeUserTiersList.Results))
 	assert.Equal("free", freeUserTiersList.Results[0].PricingTierId)
 
-	wookie, err = feature.RemoveFeatureFromPricingTier(feature1.FeatureId, freeTier.PricingTierId)
+	warrantToken, err = feature.RemoveFeatureFromPricingTier(feature1.FeatureId, freeTier.PricingTierId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotNil(wookie)
+	assert.NotNil(warrantToken)
 
 	freeUserHasFeature, err = warrant.CheckHasFeature(&warrant.FeatureCheckParams{
 		RequestOptions: warrant.RequestOptions{
@@ -1291,11 +1316,11 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	}
 	assert.Equal(1, len(freeUserTiersList.Results))
 
-	wookie, err = pricingtier.RemovePricingTierFromUser(freeTier.PricingTierId, freeUser.UserId)
+	warrantToken, err = pricingtier.RemovePricingTierFromUser(freeTier.PricingTierId, freeUser.UserId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotNil(wookie)
+	assert.NotNil(warrantToken)
 
 	freeUserTiersList, err = pricingtier.ListPricingTiersForUser(freeUser.UserId, &warrant.ListPricingTierParams{
 		ListParams: warrant.ListParams{
@@ -1311,34 +1336,41 @@ func TestPricingTiersAndFeaturesUsers(t *testing.T) {
 	assert.Equal(0, len(freeUserTiersList.Results))
 
 	// Clean up
-	err = user.Delete(freeUser.UserId)
+	warrantToken, err = user.Delete(freeUser.UserId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = user.Delete(paidUser.UserId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = user.Delete(paidUser.UserId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = pricingtier.Delete(freeTier.PricingTierId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = pricingtier.Delete(freeTier.PricingTierId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = pricingtier.Delete(paidTier.PricingTierId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = pricingtier.Delete(paidTier.PricingTierId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = feature.Delete(customFeature.FeatureId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = feature.Delete(customFeature.FeatureId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = feature.Delete(feature1.FeatureId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = feature.Delete(feature1.FeatureId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = feature.Delete(feature2.FeatureId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = feature.Delete(feature2.FeatureId)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(warrantToken)
 }
 
 func TestPricingTiersAndFeaturesTenants(t *testing.T) {
@@ -1457,11 +1489,11 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	assert.Equal(1, len(paidTenantFeaturesList.Results))
 	assert.Equal("custom-feature", paidTenantFeaturesList.Results[0].FeatureId)
 
-	wookie, err := feature.RemoveFeatureFromTenant(customFeature.FeatureId, paidTenant.TenantId)
+	warrantToken, err := feature.RemoveFeatureFromTenant(customFeature.FeatureId, paidTenant.TenantId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotNil(wookie)
+	assert.NotNil(warrantToken)
 
 	paidTenantHasFeature, err = warrant.CheckHasFeature(&warrant.FeatureCheckParams{
 		RequestOptions: warrant.RequestOptions{
@@ -1586,11 +1618,11 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	assert.Equal(1, len(freeTenantTiersList.Results))
 	assert.Equal("free", freeTenantTiersList.Results[0].PricingTierId)
 
-	wookie, err = feature.RemoveFeatureFromPricingTier(feature1.FeatureId, freeTier.PricingTierId)
+	warrantToken, err = feature.RemoveFeatureFromPricingTier(feature1.FeatureId, freeTier.PricingTierId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotNil(wookie)
+	assert.NotNil(warrantToken)
 
 	freeTenantHasFeature, err = warrant.CheckHasFeature(&warrant.FeatureCheckParams{
 		RequestOptions: warrant.RequestOptions{
@@ -1633,11 +1665,11 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	}
 	assert.Equal(1, len(freeTenantTiersList.Results))
 
-	wookie, err = pricingtier.RemovePricingTierFromTenant(freeTier.PricingTierId, freeTenant.TenantId)
+	warrantToken, err = pricingtier.RemovePricingTierFromTenant(freeTier.PricingTierId, freeTenant.TenantId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotNil(wookie)
+	assert.NotNil(warrantToken)
 
 	freeTenantTiersList, err = pricingtier.ListPricingTiersForTenant(freeTenant.TenantId, &warrant.ListPricingTierParams{
 		ListParams: warrant.ListParams{
@@ -1653,34 +1685,41 @@ func TestPricingTiersAndFeaturesTenants(t *testing.T) {
 	assert.Equal(0, len(freeTenantTiersList.Results))
 
 	// Clean up
-	err = tenant.Delete(freeTenant.TenantId)
+	warrantToken, err = tenant.Delete(freeTenant.TenantId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = tenant.Delete(paidTenant.TenantId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = tenant.Delete(paidTenant.TenantId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = pricingtier.Delete(freeTier.PricingTierId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = pricingtier.Delete(freeTier.PricingTierId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = pricingtier.Delete(paidTier.PricingTierId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = pricingtier.Delete(paidTier.PricingTierId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = feature.Delete(customFeature.FeatureId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = feature.Delete(customFeature.FeatureId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = feature.Delete(feature1.FeatureId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = feature.Delete(feature1.FeatureId)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = feature.Delete(feature2.FeatureId)
+	assert.NotNil(warrantToken)
+	warrantToken, err = feature.Delete(feature2.FeatureId)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(warrantToken)
 }
 
 func TestSessions(t *testing.T) {
@@ -1722,15 +1761,17 @@ func TestSessions(t *testing.T) {
 	assert.NotEmpty(ssDashUrl)
 
 	// Clean up
-	err = user.Delete(user1.UserId)
+	warrantToken, err := user.Delete(user1.UserId)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(warrantToken)
 
-	err = tenant.Delete(tenant1.TenantId)
+	warrantToken, err = tenant.Delete(tenant1.TenantId)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(warrantToken)
 }
 
 func TestWarrants(t *testing.T) {
@@ -1786,7 +1827,7 @@ func TestWarrants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotNil(newWarrant.Wookie)
+	assert.NotNil(newWarrant.WarrantToken)
 
 	checkResult, err = warrant.Check(&warrant.WarrantCheckParams{
 		RequestOptions: warrant.RequestOptions{
@@ -1823,7 +1864,7 @@ func TestWarrants(t *testing.T) {
 	assert.Equal("Permission 1", queryResult.Results[0].Meta["name"])
 	assert.Equal("Permission with id 1", queryResult.Results[0].Meta["description"])
 
-	wookie, err := warrant.Delete(&warrant.WarrantParams{
+	warrantToken, err := warrant.Delete(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypePermission,
 		ObjectId:   newPermission.PermissionId,
 		Relation:   "member",
@@ -1835,7 +1876,7 @@ func TestWarrants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotNil(wookie)
+	assert.NotNil(warrantToken)
 
 	checkResult, err = warrant.Check(&warrant.WarrantCheckParams{
 		RequestOptions: warrant.RequestOptions{
@@ -1859,15 +1900,17 @@ func TestWarrants(t *testing.T) {
 	assert.False(checkResult)
 
 	// Clean up
-	err = user.Delete(newUser.UserId)
+	warrantToken, err = user.Delete(newUser.UserId)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(warrantToken)
 
-	err = permission.Delete(newPermission.PermissionId)
+	warrantToken, err = permission.Delete(newPermission.PermissionId)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(warrantToken)
 }
 
 func TestBatchWarrants(t *testing.T) {
@@ -1955,8 +1998,8 @@ func TestBatchWarrants(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Len(warrants, 2)
-	assert.NotNil(warrants[0].Wookie)
-	assert.NotNil(warrants[1].Wookie)
+	assert.NotNil(warrants[0].WarrantToken)
+	assert.NotNil(warrants[1].WarrantToken)
 
 	userHasPermission1, err = warrant.Check(&warrant.WarrantCheckParams{
 		RequestOptions: warrant.RequestOptions{
@@ -1988,7 +2031,7 @@ func TestBatchWarrants(t *testing.T) {
 	}
 	assert.True(userHasPermission2)
 
-	wookie, err := warrant.BatchDelete([]warrant.WarrantParams{
+	warrantToken, err := warrant.BatchDelete([]warrant.WarrantParams{
 		{
 			ObjectType: warrant.ObjectTypePermission,
 			ObjectId:   permission1.PermissionId,
@@ -2011,13 +2054,14 @@ func TestBatchWarrants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotNil(wookie)
+	assert.NotNil(warrantToken)
 
-	err = object.BatchDelete([]warrant.ObjectParams{
+	warrantToken, err = object.BatchDelete([]warrant.ObjectParams{
 		{ObjectType: warrant.ObjectTypePermission, ObjectId: permission1.PermissionId},
 		{ObjectType: warrant.ObjectTypePermission, ObjectId: permission2.PermissionId},
 		{ObjectType: warrant.ObjectTypeUser, ObjectId: newUser.UserId},
 	})
+	assert.NotNil(warrantToken)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2104,7 +2148,7 @@ func TestWarrantPolicies(t *testing.T) {
 	assert.False(checkResult)
 
 	// Clean up
-	wookie, err := warrant.Delete(&warrant.WarrantParams{
+	warrantToken, err := warrant.Delete(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypePermission,
 		ObjectId:   newPermission.PermissionId,
 		Relation:   "member",
@@ -2117,17 +2161,19 @@ func TestWarrantPolicies(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotNil(wookie)
+	assert.NotNil(warrantToken)
 
-	err = user.Delete(newUser.UserId)
+	warrantToken, err = user.Delete(newUser.UserId)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(warrantToken)
 
-	err = permission.Delete(newPermission.PermissionId)
+	warrantToken, err = permission.Delete(newPermission.PermissionId)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(warrantToken)
 }
 
 func TestObjectTypes(t *testing.T) {
@@ -2147,7 +2193,7 @@ func TestObjectTypes(t *testing.T) {
 	assert.Equal("new-type", newType.Type)
 	assert.NotNil(newType.Relations["relation-1"])
 	assert.Nil(newType.Relations["relation-2"])
-	assert.NotNil(newType.Wookie)
+	assert.NotNil(newType.WarrantToken)
 
 	objType, err := objecttype.Get("new-type", &warrant.ObjectTypeParams{})
 	if err != nil {
@@ -2177,13 +2223,13 @@ func TestObjectTypes(t *testing.T) {
 	assert.Len(objType.Relations, 2)
 	assert.NotNil(objType.Relations["relation-1"])
 	assert.NotNil(objType.Relations["relation-2"])
-	assert.NotNil(objType.Wookie)
+	assert.NotNil(objType.WarrantToken)
 
-	wookie, err := objecttype.Delete("new-type")
+	warrantToken, err := objecttype.Delete("new-type")
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotNil(wookie)
+	assert.NotNil(warrantToken)
 
 	typesList, err = objecttype.ListObjectTypes(&warrant.ListObjectTypeParams{})
 	if err != nil {
@@ -2238,10 +2284,11 @@ func TestObjects(t *testing.T) {
 	assert.Len(obj.Meta, 1)
 	assert.Equal("new name", obj.Meta["name"])
 
-	err = object.Delete("role", "admin2")
+	warrantToken, err := object.Delete("role", "admin2")
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(warrantToken)
 
 	objectsList, err = object.ListObjects(&warrant.ListObjectParams{})
 	if err != nil {
@@ -2301,7 +2348,7 @@ func TestBatchObjects(t *testing.T) {
 	assert.Equal("resources", fetchedObjects.Results[0].ObjectId)
 	assert.Equal(map[string]interface{}{"description": "Helpful documents"}, fetchedObjects.Results[0].Meta)
 
-	err = object.BatchDelete([]warrant.ObjectParams{
+	warrantToken, err := object.BatchDelete([]warrant.ObjectParams{
 		{ObjectType: "document", ObjectId: "document-a"},
 		{ObjectType: "document", ObjectId: "document-b"},
 		{ObjectType: "folder", ObjectId: "resources"},
@@ -2309,6 +2356,7 @@ func TestBatchObjects(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert.NotNil(warrantToken)
 
 	fetchedObjects, err = object.ListObjects(&warrant.ListObjectParams{
 		ListParams: warrant.ListParams{

--- a/examples/live_test.go
+++ b/examples/live_test.go
@@ -1969,11 +1969,13 @@ func TestObjects(t *testing.T) {
 	assert.Equal("admin2", obj.ObjectId)
 	assert.Len(obj.Meta, 0)
 
-	objects, err := object.ListObjects(&warrant.ListObjectParams{})
+	objectsList, err := object.ListObjects(&warrant.ListObjectParams{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Len(objects, 1)
+	assert.Len(objectsList.Results, 1)
+	assert.Equal("role", objectsList.Results[0].GetObjectType())
+	assert.Equal("admin2", objectsList.Results[0].GetObjectId())
 
 	meta := make(map[string]interface{})
 	meta["name"] = "new name"
@@ -1995,9 +1997,9 @@ func TestObjects(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	objects, err = object.ListObjects(&warrant.ListObjectParams{})
+	objectsList, err = object.ListObjects(&warrant.ListObjectParams{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Len(objects, 0)
+	assert.Len(objectsList.Results, 0)
 }

--- a/feature.go
+++ b/feature.go
@@ -3,7 +3,8 @@ package warrant
 const ObjectTypeFeature = "feature"
 
 type Feature struct {
-	FeatureId string `json:"featureId"`
+	FeatureId string                 `json:"featureId"`
+	Meta      map[string]interface{} `json:"meta,omitempty"`
 }
 
 func (feature Feature) GetObjectType() string {
@@ -20,5 +21,6 @@ type ListFeatureParams struct {
 
 type FeatureParams struct {
 	RequestOptions
-	FeatureId string `json:"featureId"`
+	FeatureId string                 `json:"featureId"`
+	Meta      map[string]interface{} `json:"meta,omitempty"`
 }

--- a/feature/client.go
+++ b/feature/client.go
@@ -1,12 +1,10 @@
 package feature
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
 
-	"github.com/google/go-querystring/query"
 	"github.com/warrant-dev/warrant-go/v5"
+	"github.com/warrant-dev/warrant-go/v5/object"
 )
 
 type Client struct {
@@ -20,20 +18,24 @@ func NewClient(config warrant.ClientConfig) Client {
 }
 
 func (c Client) Create(params *warrant.FeatureParams) (*warrant.Feature, error) {
-	resp, err := c.apiClient.MakeRequest("POST", "/v1/features", params, &warrant.RequestOptions{})
+	objectParams := warrant.ObjectParams{
+		ObjectType:     warrant.ObjectTypeFeature,
+		RequestOptions: params.RequestOptions,
+	}
+	if params.FeatureId != "" {
+		objectParams.ObjectId = params.FeatureId
+	}
+	if params.Meta != nil {
+		objectParams.Meta = params.Meta
+	}
+	object, err := object.Create(&objectParams)
 	if err != nil {
 		return nil, err
 	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, warrant.WrapError("Error reading response", err)
-	}
-	var newFeature warrant.Feature
-	err = json.Unmarshal([]byte(body), &newFeature)
-	if err != nil {
-		return nil, warrant.WrapError("Invalid response from server", err)
-	}
-	return &newFeature, nil
+	return &warrant.Feature{
+		FeatureId: object.ObjectId,
+		Meta:      object.Meta,
+	}, nil
 }
 
 func Create(params *warrant.FeatureParams) (*warrant.Feature, error) {
@@ -41,98 +43,115 @@ func Create(params *warrant.FeatureParams) (*warrant.Feature, error) {
 }
 
 func (c Client) Get(featureId string, params *warrant.FeatureParams) (*warrant.Feature, error) {
-	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/features/%s", featureId), nil, &params.RequestOptions)
+	objectParams := warrant.ObjectParams{
+		ObjectType:     warrant.ObjectTypeFeature,
+		ObjectId:       featureId,
+		RequestOptions: params.RequestOptions,
+		Meta:           params.Meta,
+	}
+	object, err := object.Get(warrant.ObjectTypeFeature, featureId, &objectParams)
 	if err != nil {
 		return nil, err
 	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, warrant.WrapError("Error reading response", err)
-	}
-	var foundFeature warrant.Feature
-	err = json.Unmarshal([]byte(body), &foundFeature)
-	if err != nil {
-		return nil, warrant.WrapError("Invalid response from server", err)
-	}
-	return &foundFeature, nil
+	return &warrant.Feature{
+		FeatureId: object.ObjectId,
+		Meta:      object.Meta,
+	}, nil
 }
 
 func Get(featureId string, params *warrant.FeatureParams) (*warrant.Feature, error) {
 	return getClient().Get(featureId, params)
 }
 
-func (c Client) Delete(featureId string) error {
-	resp, err := c.apiClient.MakeRequest("DELETE", fmt.Sprintf("/v1/features/%s", featureId), nil, &warrant.RequestOptions{})
+func (c Client) Update(featureId string, params *warrant.FeatureParams) (*warrant.Feature, error) {
+	objectParams := warrant.ObjectParams{
+		ObjectType:     warrant.ObjectTypeFeature,
+		ObjectId:       featureId,
+		RequestOptions: params.RequestOptions,
+		Meta:           params.Meta,
+	}
+	object, err := object.Update(warrant.ObjectTypeFeature, featureId, &objectParams)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	respStatus := resp.StatusCode
-	if respStatus < 200 || respStatus >= 400 {
-		msg, err := io.ReadAll(resp.Body)
-		errMsg := ""
-		if err == nil {
-			errMsg = string(msg)
-		}
-		return warrant.Error{
-			Message: fmt.Sprintf("HTTP %d %s", respStatus, errMsg),
-		}
-	}
-	return nil
+	return &warrant.Feature{
+		FeatureId: object.ObjectId,
+		Meta:      object.Meta,
+	}, nil
+}
+
+func Update(featureId string, params *warrant.FeatureParams) (*warrant.Feature, error) {
+	return getClient().Update(featureId, params)
+}
+
+func (c Client) Delete(featureId string) error {
+	return object.Delete(warrant.ObjectTypeFeature, featureId)
 }
 
 func Delete(featureId string) error {
 	return getClient().Delete(featureId)
 }
 
-func (c Client) ListFeatures(listParams *warrant.ListFeatureParams) ([]warrant.Feature, error) {
-	queryParams, err := query.Values(listParams)
+func (c Client) ListFeatures(listParams *warrant.ListFeatureParams) (warrant.ListResponse[warrant.Feature], error) {
+	var featuresListResponse warrant.ListResponse[warrant.Feature]
+
+	objectsListResponse, err := object.ListObjects(&warrant.ListObjectParams{
+		ListParams: listParams.ListParams,
+		ObjectType: warrant.ObjectTypeFeature,
+	})
 	if err != nil {
-		return nil, warrant.WrapError("Could not parse listParams", err)
+		return featuresListResponse, err
 	}
 
-	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/features?%s", queryParams.Encode()), nil, &listParams.RequestOptions)
-	if err != nil {
-		return nil, err
+	features := make([]warrant.Feature, 0)
+	for _, object := range objectsListResponse.Results {
+		features = append(features, warrant.Feature{
+			FeatureId: object.ObjectId,
+			Meta:      object.Meta,
+		})
 	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, warrant.WrapError("Error reading response", err)
+
+	featuresListResponse = warrant.ListResponse[warrant.Feature]{
+		Results:    features,
+		PrevCursor: objectsListResponse.PrevCursor,
+		NextCursor: objectsListResponse.NextCursor,
 	}
-	var permissions []warrant.Feature
-	err = json.Unmarshal([]byte(body), &permissions)
-	if err != nil {
-		return nil, warrant.WrapError("Invalid response from server", err)
-	}
-	return permissions, nil
+
+	return featuresListResponse, nil
 }
 
-func ListFeatures(listParams *warrant.ListFeatureParams) ([]warrant.Feature, error) {
+func ListFeatures(listParams *warrant.ListFeatureParams) (warrant.ListResponse[warrant.Feature], error) {
 	return getClient().ListFeatures(listParams)
 }
 
-func (c Client) ListFeaturesForPricingTier(pricingTierId string, listParams *warrant.ListFeatureParams) ([]warrant.Feature, error) {
-	queryParams, err := query.Values(listParams)
+func (c Client) ListFeaturesForPricingTier(pricingTierId string, listParams *warrant.ListFeatureParams) (warrant.ListResponse[warrant.Feature], error) {
+	var featuresListResponse warrant.ListResponse[warrant.Feature]
+
+	queryResponse, err := warrant.Query(fmt.Sprintf("select feature where pricing-tier:%s is *", pricingTierId), &warrant.QueryParams{
+		ListParams: listParams.ListParams,
+	})
 	if err != nil {
-		return nil, warrant.WrapError("Could not parse listParams", err)
+		return featuresListResponse, err
 	}
 
-	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/pricing-tiers/%s/features?%s", pricingTierId, queryParams.Encode()), nil, &listParams.RequestOptions)
-	if err != nil {
-		return nil, err
+	features := make([]warrant.Feature, 0)
+	for _, queryResult := range queryResponse.Results {
+		features = append(features, warrant.Feature{
+			FeatureId: queryResult.ObjectId,
+			Meta:      queryResult.Meta,
+		})
 	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, warrant.WrapError("Error reading response", err)
+
+	featuresListResponse = warrant.ListResponse[warrant.Feature]{
+		Results:    features,
+		PrevCursor: queryResponse.PrevCursor,
+		NextCursor: queryResponse.NextCursor,
 	}
-	var features []warrant.Feature
-	err = json.Unmarshal([]byte(body), &features)
-	if err != nil {
-		return nil, warrant.WrapError("Invalid response from server", err)
-	}
-	return features, nil
+
+	return featuresListResponse, nil
 }
 
-func ListFeaturesForPricingTier(pricingTierId string, listParams *warrant.ListFeatureParams) ([]warrant.Feature, error) {
+func ListFeaturesForPricingTier(pricingTierId string, listParams *warrant.ListFeatureParams) (warrant.ListResponse[warrant.Feature], error) {
 	return getClient().ListFeaturesForPricingTier(pricingTierId, listParams)
 }
 
@@ -168,29 +187,34 @@ func RemoveFeatureFromPricingTier(featureId string, pricingTierId string) error 
 	return getClient().RemoveFeatureFromPricingTier(featureId, pricingTierId)
 }
 
-func (c Client) ListFeaturesForTenant(tenantId string, listParams *warrant.ListFeatureParams) ([]warrant.Feature, error) {
-	queryParams, err := query.Values(listParams)
+func (c Client) ListFeaturesForTenant(tenantId string, listParams *warrant.ListFeatureParams) (warrant.ListResponse[warrant.Feature], error) {
+	var featuresListResponse warrant.ListResponse[warrant.Feature]
+
+	queryResponse, err := warrant.Query(fmt.Sprintf("select feature where tenant:%s is *", tenantId), &warrant.QueryParams{
+		ListParams: listParams.ListParams,
+	})
 	if err != nil {
-		return nil, warrant.WrapError("Could not parse listParams", err)
+		return featuresListResponse, err
 	}
 
-	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants/%s/features?%s", tenantId, queryParams.Encode()), nil, &listParams.RequestOptions)
-	if err != nil {
-		return nil, err
+	features := make([]warrant.Feature, 0)
+	for _, queryResult := range queryResponse.Results {
+		features = append(features, warrant.Feature{
+			FeatureId: queryResult.ObjectId,
+			Meta:      queryResult.Meta,
+		})
 	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, warrant.WrapError("Error reading response", err)
+
+	featuresListResponse = warrant.ListResponse[warrant.Feature]{
+		Results:    features,
+		PrevCursor: queryResponse.PrevCursor,
+		NextCursor: queryResponse.NextCursor,
 	}
-	var features []warrant.Feature
-	err = json.Unmarshal([]byte(body), &features)
-	if err != nil {
-		return nil, warrant.WrapError("Invalid response from server", err)
-	}
-	return features, nil
+
+	return featuresListResponse, nil
 }
 
-func ListFeaturesForTenant(tenantId string, listParams *warrant.ListFeatureParams) ([]warrant.Feature, error) {
+func ListFeaturesForTenant(tenantId string, listParams *warrant.ListFeatureParams) (warrant.ListResponse[warrant.Feature], error) {
 	return getClient().ListFeaturesForTenant(tenantId, listParams)
 }
 
@@ -226,29 +250,34 @@ func RemoveFeatureFromTenant(featureId string, tenantId string) error {
 	return getClient().RemoveFeatureFromTenant(featureId, tenantId)
 }
 
-func (c Client) ListFeaturesForUser(userId string, listParams *warrant.ListFeatureParams) ([]warrant.Feature, error) {
-	queryParams, err := query.Values(listParams)
+func (c Client) ListFeaturesForUser(userId string, listParams *warrant.ListFeatureParams) (warrant.ListResponse[warrant.Feature], error) {
+	var featuresListResponse warrant.ListResponse[warrant.Feature]
+
+	queryResponse, err := warrant.Query(fmt.Sprintf("select feature where user:%s is *", userId), &warrant.QueryParams{
+		ListParams: listParams.ListParams,
+	})
 	if err != nil {
-		return nil, warrant.WrapError("Could not parse listParams", err)
+		return featuresListResponse, err
 	}
 
-	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/features?%s", userId, queryParams.Encode()), nil, &listParams.RequestOptions)
-	if err != nil {
-		return nil, err
+	features := make([]warrant.Feature, 0)
+	for _, queryResult := range queryResponse.Results {
+		features = append(features, warrant.Feature{
+			FeatureId: queryResult.ObjectId,
+			Meta:      queryResult.Meta,
+		})
 	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, warrant.WrapError("Error reading response", err)
+
+	featuresListResponse = warrant.ListResponse[warrant.Feature]{
+		Results:    features,
+		PrevCursor: queryResponse.PrevCursor,
+		NextCursor: queryResponse.NextCursor,
 	}
-	var features []warrant.Feature
-	err = json.Unmarshal([]byte(body), &features)
-	if err != nil {
-		return nil, warrant.WrapError("Invalid response from server", err)
-	}
-	return features, nil
+
+	return featuresListResponse, nil
 }
 
-func ListFeaturesForUser(userId string, listParams *warrant.ListFeatureParams) ([]warrant.Feature, error) {
+func ListFeaturesForUser(userId string, listParams *warrant.ListFeatureParams) (warrant.ListResponse[warrant.Feature], error) {
 	return getClient().ListFeaturesForUser(userId, listParams)
 }
 

--- a/feature/client.go
+++ b/feature/client.go
@@ -84,11 +84,11 @@ func Update(featureId string, params *warrant.FeatureParams) (*warrant.Feature, 
 	return getClient().Update(featureId, params)
 }
 
-func (c Client) Delete(featureId string) error {
+func (c Client) Delete(featureId string) (string, error) {
 	return object.Delete(warrant.ObjectTypeFeature, featureId)
 }
 
-func Delete(featureId string) error {
+func Delete(featureId string) (string, error) {
 	return getClient().Delete(featureId)
 }
 

--- a/feature/client.go
+++ b/feature/client.go
@@ -171,7 +171,7 @@ func AssignFeatureToPricingTier(featureId string, pricingTierId string) (*warran
 	return getClient().AssignFeatureToPricingTier(featureId, pricingTierId)
 }
 
-func (c Client) RemoveFeatureFromPricingTier(featureId string, pricingTierId string) error {
+func (c Client) RemoveFeatureFromPricingTier(featureId string, pricingTierId string) (string, error) {
 	return warrant.NewClient(c.apiClient.Config).Delete(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypeFeature,
 		ObjectId:   featureId,
@@ -183,7 +183,7 @@ func (c Client) RemoveFeatureFromPricingTier(featureId string, pricingTierId str
 	})
 }
 
-func RemoveFeatureFromPricingTier(featureId string, pricingTierId string) error {
+func RemoveFeatureFromPricingTier(featureId string, pricingTierId string) (string, error) {
 	return getClient().RemoveFeatureFromPricingTier(featureId, pricingTierId)
 }
 
@@ -234,7 +234,7 @@ func AssignFeatureToTenant(featureId string, tenantId string) (*warrant.Warrant,
 	return getClient().AssignFeatureToTenant(featureId, tenantId)
 }
 
-func (c Client) RemoveFeatureFromTenant(featureId string, tenantId string) error {
+func (c Client) RemoveFeatureFromTenant(featureId string, tenantId string) (string, error) {
 	return warrant.NewClient(c.apiClient.Config).Delete(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypeFeature,
 		ObjectId:   featureId,
@@ -246,7 +246,7 @@ func (c Client) RemoveFeatureFromTenant(featureId string, tenantId string) error
 	})
 }
 
-func RemoveFeatureFromTenant(featureId string, tenantId string) error {
+func RemoveFeatureFromTenant(featureId string, tenantId string) (string, error) {
 	return getClient().RemoveFeatureFromTenant(featureId, tenantId)
 }
 
@@ -297,7 +297,7 @@ func AssignFeatureToUser(featureId string, userId string) (*warrant.Warrant, err
 	return getClient().AssignFeatureToUser(featureId, userId)
 }
 
-func (c Client) RemoveFeatureFromUser(featureId string, userId string) error {
+func (c Client) RemoveFeatureFromUser(featureId string, userId string) (string, error) {
 	return warrant.NewClient(c.apiClient.Config).Delete(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypeFeature,
 		ObjectId:   featureId,
@@ -309,7 +309,7 @@ func (c Client) RemoveFeatureFromUser(featureId string, userId string) error {
 	})
 }
 
-func RemoveFeatureFromUser(featureId string, userId string) error {
+func RemoveFeatureFromUser(featureId string, userId string) (string, error) {
 	return getClient().RemoveFeatureFromUser(featureId, userId)
 }
 

--- a/list.go
+++ b/list.go
@@ -2,12 +2,15 @@ package warrant
 
 type ListParams struct {
 	RequestOptions
-	BeforeId    string `json:"beforeId"`
-	BeforeValue string `json:"beforeValue"`
-	AfterId     string `json:"afterId"`
-	AfterValue  string `json:"afterValue"`
-	SortBy      string `json:"sortBy"`
-	SortOrder   string `json:"sortOrder"`
-	Page        int    `json:"page"`
-	Limit       int    `json:"limit"`
+	PrevCursor string `json:"prevCursor,omitempty" url:"prevCursor,omitempty"`
+	NextCursor string `json:"nextCursor,omitempty" url:"nextCursor,omitempty"`
+	SortBy     string `json:"sortBy,omitempty" url:"sortBy,omitempty"`
+	SortOrder  string `json:"sortOrder,omitempty" url:"sortOrder,omitempty"`
+	Limit      int    `json:"limit,omitempty" url:"limit,omitempty"`
+}
+
+type ListResponse[T any] struct {
+	Results    []T    `json:"results,omitempty"`
+	PrevCursor string `json:"prevCursor,omitempty"`
+	NextCursor string `json:"nextCursor,omitempty"`
 }

--- a/object/client.go
+++ b/object/client.go
@@ -20,7 +20,7 @@ func NewClient(config warrant.ClientConfig) Client {
 }
 
 func (c Client) Create(params *warrant.ObjectParams) (*warrant.Object, error) {
-	resp, err := c.apiClient.MakeRequest("POST", "/v1/objects", params, &warrant.RequestOptions{})
+	resp, err := c.apiClient.MakeRequest("POST", "/v2/objects", params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func Create(params *warrant.ObjectParams) (*warrant.Object, error) {
 }
 
 func (c Client) Get(objectType string, objectId string, params *warrant.ObjectParams) (*warrant.Object, error) {
-	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/objects/%s/%s", objectType, objectId), nil, &params.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v2/objects/%s/%s", objectType, objectId), nil, &params.RequestOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func Get(objectType string, objectId string, params *warrant.ObjectParams) (*war
 }
 
 func (c Client) Update(objectType string, objectId string, params *warrant.ObjectParams) (*warrant.Object, error) {
-	resp, err := c.apiClient.MakeRequest("PUT", fmt.Sprintf("/v1/objects/%s/%s", objectType, objectId), params, &warrant.RequestOptions{})
+	resp, err := c.apiClient.MakeRequest("PUT", fmt.Sprintf("/v2/objects/%s/%s", objectType, objectId), params, &warrant.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func Update(objectType string, objectId string, params *warrant.ObjectParams) (*
 }
 
 func (c Client) Delete(objectType string, objectId string) error {
-	_, err := c.apiClient.MakeRequest("DELETE", fmt.Sprintf("/v1/objects/%s/%s", objectType, objectId), nil, &warrant.RequestOptions{})
+	_, err := c.apiClient.MakeRequest("DELETE", fmt.Sprintf("/v2/objects/%s/%s", objectType, objectId), nil, &warrant.RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -94,29 +94,29 @@ func Delete(objectType string, objectId string) error {
 	return getClient().Delete(objectType, objectId)
 }
 
-func (c Client) ListObjects(listParams *warrant.ListObjectParams) ([]warrant.Object, error) {
+func (c Client) ListObjects(listParams *warrant.ListObjectParams) (warrant.ListResponse[warrant.Object], error) {
+	var objectsListResponse warrant.ListResponse[warrant.Object]
 	queryParams, err := query.Values(listParams)
 	if err != nil {
-		return nil, warrant.WrapError("Could not parse listParams", err)
+		return objectsListResponse, warrant.WrapError("Could not parse listParams", err)
 	}
 
-	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/objects?%s", queryParams.Encode()), nil, &listParams.RequestOptions)
+	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v2/objects?%s", queryParams.Encode()), objectsListResponse, &listParams.RequestOptions)
 	if err != nil {
-		return nil, err
+		return objectsListResponse, err
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, warrant.WrapError("Error reading response", err)
+		return objectsListResponse, warrant.WrapError("Error reading response", err)
 	}
-	var permissions []warrant.Object
-	err = json.Unmarshal([]byte(body), &permissions)
+	err = json.Unmarshal([]byte(body), &objectsListResponse)
 	if err != nil {
-		return nil, warrant.WrapError("Invalid response from server", err)
+		return objectsListResponse, warrant.WrapError("Invalid response from server", err)
 	}
-	return permissions, nil
+	return objectsListResponse, nil
 }
 
-func ListObjects(listParams *warrant.ListObjectParams) ([]warrant.Object, error) {
+func ListObjects(listParams *warrant.ListObjectParams) (warrant.ListResponse[warrant.Object], error) {
 	return getClient().ListObjects(listParams)
 }
 

--- a/object/client.go
+++ b/object/client.go
@@ -103,27 +103,29 @@ func Update(objectType string, objectId string, params *warrant.ObjectParams) (*
 	return getClient().Update(objectType, objectId, params)
 }
 
-func (c Client) Delete(objectType string, objectId string) error {
-	_, err := c.apiClient.MakeRequest("DELETE", fmt.Sprintf("/v2/objects/%s/%s", objectType, objectId), nil, &warrant.RequestOptions{})
+func (c Client) Delete(objectType string, objectId string) (string, error) {
+	resp, err := c.apiClient.MakeRequest("DELETE", fmt.Sprintf("/v2/objects/%s/%s", objectType, objectId), nil, &warrant.RequestOptions{})
 	if err != nil {
-		return err
+		return "", err
 	}
-	return nil
+	warrantToken := resp.Header.Get("Warrant-Token")
+	return warrantToken, nil
 }
 
-func Delete(objectType string, objectId string) error {
+func Delete(objectType string, objectId string) (string, error) {
 	return getClient().Delete(objectType, objectId)
 }
 
-func (c Client) BatchDelete(params []warrant.ObjectParams) error {
-	_, err := c.apiClient.MakeRequest("DELETE", "/v2/objects", params, &warrant.RequestOptions{})
+func (c Client) BatchDelete(params []warrant.ObjectParams) (string, error) {
+	resp, err := c.apiClient.MakeRequest("DELETE", "/v2/objects", params, &warrant.RequestOptions{})
 	if err != nil {
-		return err
+		return "", err
 	}
-	return nil
+	warrantToken := resp.Header.Get("Warrant-Token")
+	return warrantToken, nil
 }
 
-func BatchDelete(params []warrant.ObjectParams) error {
+func BatchDelete(params []warrant.ObjectParams) (string, error) {
 	return getClient().BatchDelete(params)
 }
 

--- a/object/client.go
+++ b/object/client.go
@@ -40,6 +40,27 @@ func Create(params *warrant.ObjectParams) (*warrant.Object, error) {
 	return getClient().Create(params)
 }
 
+func (c Client) BatchCreate(params []warrant.ObjectParams) ([]warrant.Object, error) {
+	resp, err := c.apiClient.MakeRequest("POST", "/v2/objects", params, &warrant.RequestOptions{})
+	if err != nil {
+		return nil, err
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, warrant.WrapError("Error reading response", err)
+	}
+	var newObjects []warrant.Object
+	err = json.Unmarshal([]byte(body), &newObjects)
+	if err != nil {
+		return nil, warrant.WrapError("Invalid response from server", err)
+	}
+	return newObjects, nil
+}
+
+func BatchCreate(params []warrant.ObjectParams) ([]warrant.Object, error) {
+	return getClient().BatchCreate(params)
+}
+
 func (c Client) Get(objectType string, objectId string, params *warrant.ObjectParams) (*warrant.Object, error) {
 	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v2/objects/%s/%s", objectType, objectId), nil, &params.RequestOptions)
 	if err != nil {
@@ -92,6 +113,18 @@ func (c Client) Delete(objectType string, objectId string) error {
 
 func Delete(objectType string, objectId string) error {
 	return getClient().Delete(objectType, objectId)
+}
+
+func (c Client) BatchDelete(params []warrant.ObjectParams) error {
+	_, err := c.apiClient.MakeRequest("DELETE", "/v2/objects", params, &warrant.RequestOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func BatchDelete(params []warrant.ObjectParams) error {
+	return getClient().BatchDelete(params)
 }
 
 func (c Client) ListObjects(listParams *warrant.ListObjectParams) (warrant.ListResponse[warrant.Object], error) {

--- a/object/client.go
+++ b/object/client.go
@@ -28,6 +28,7 @@ func (c Client) Create(params *warrant.ObjectParams) (*warrant.Object, error) {
 	if err != nil {
 		return nil, warrant.WrapError("Error reading response", err)
 	}
+	defer resp.Body.Close()
 	var newObject warrant.Object
 	err = json.Unmarshal([]byte(body), &newObject)
 	if err != nil {
@@ -49,6 +50,7 @@ func (c Client) BatchCreate(params []warrant.ObjectParams) ([]warrant.Object, er
 	if err != nil {
 		return nil, warrant.WrapError("Error reading response", err)
 	}
+	defer resp.Body.Close()
 	var newObjects []warrant.Object
 	err = json.Unmarshal([]byte(body), &newObjects)
 	if err != nil {
@@ -70,6 +72,7 @@ func (c Client) Get(objectType string, objectId string, params *warrant.ObjectPa
 	if err != nil {
 		return nil, warrant.WrapError("Error reading response", err)
 	}
+	defer resp.Body.Close()
 	var foundObject warrant.Object
 	err = json.Unmarshal([]byte(body), &foundObject)
 	if err != nil {
@@ -91,6 +94,7 @@ func (c Client) Update(objectType string, objectId string, params *warrant.Objec
 	if err != nil {
 		return nil, warrant.WrapError("Error reading response", err)
 	}
+	defer resp.Body.Close()
 	var updatedObject warrant.Object
 	err = json.Unmarshal([]byte(body), &updatedObject)
 	if err != nil {
@@ -108,6 +112,7 @@ func (c Client) Delete(objectType string, objectId string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer resp.Body.Close()
 	warrantToken := resp.Header.Get("Warrant-Token")
 	return warrantToken, nil
 }
@@ -121,6 +126,7 @@ func (c Client) BatchDelete(params []warrant.ObjectParams) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer resp.Body.Close()
 	warrantToken := resp.Header.Get("Warrant-Token")
 	return warrantToken, nil
 }
@@ -144,6 +150,7 @@ func (c Client) ListObjects(listParams *warrant.ListObjectParams) (warrant.ListR
 	if err != nil {
 		return objectsListResponse, warrant.WrapError("Error reading response", err)
 	}
+	defer resp.Body.Close()
 	err = json.Unmarshal([]byte(body), &objectsListResponse)
 	if err != nil {
 		return objectsListResponse, warrant.WrapError("Invalid response from server", err)

--- a/objecttype.go
+++ b/objecttype.go
@@ -1,9 +1,9 @@
 package warrant
 
 type ObjectType struct {
-	Type      string                 `json:"type"`
-	Relations map[string]interface{} `json:"relations"`
-	Wookie    string                 `json:"wookie,omitempty"`
+	Type         string                 `json:"type"`
+	Relations    map[string]interface{} `json:"relations"`
+	WarrantToken string                 `json:"warrantToken,omitempty"`
 }
 
 type ListObjectTypeParams struct {

--- a/objecttype.go
+++ b/objecttype.go
@@ -3,6 +3,7 @@ package warrant
 type ObjectType struct {
 	Type      string                 `json:"type"`
 	Relations map[string]interface{} `json:"relations"`
+	Wookie    string                 `json:"wookie,omitempty"`
 }
 
 type ListObjectTypeParams struct {

--- a/objecttype/client.go
+++ b/objecttype/client.go
@@ -33,8 +33,8 @@ func (c Client) Create(params *warrant.ObjectTypeParams) (*warrant.ObjectType, e
 	if err != nil {
 		return nil, warrant.WrapError("Invalid response from server", err)
 	}
-	wookie := resp.Header.Get("Warrant-Token")
-	newObjectType.Wookie = wookie
+	warrantToken := resp.Header.Get("Warrant-Token")
+	newObjectType.WarrantToken = warrantToken
 	return &newObjectType, nil
 }
 
@@ -77,8 +77,8 @@ func (c Client) Update(objectTypeId string, params *warrant.ObjectTypeParams) (*
 	if err != nil {
 		return nil, warrant.WrapError("Invalid response from server", err)
 	}
-	wookie := resp.Header.Get("Warrant-Token")
-	updatedObjectType.Wookie = wookie
+	warrantToken := resp.Header.Get("Warrant-Token")
+	updatedObjectType.WarrantToken = warrantToken
 	return &updatedObjectType, nil
 }
 
@@ -100,9 +100,9 @@ func (c Client) BatchUpdate(params []warrant.ObjectTypeParams) ([]warrant.Object
 	if err != nil {
 		return nil, warrant.WrapError("Invalid response from server", err)
 	}
-	wookie := resp.Header.Get("Warrant-Token")
+	warrantToken := resp.Header.Get("Warrant-Token")
 	for i := range updatedObjectTypes {
-		updatedObjectTypes[i].Wookie = wookie
+		updatedObjectTypes[i].WarrantToken = warrantToken
 	}
 	return updatedObjectTypes, nil
 }
@@ -116,8 +116,8 @@ func (c Client) Delete(objectTypeId string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	wookie := resp.Header.Get("Warrant-Token")
-	return wookie, nil
+	warrantToken := resp.Header.Get("Warrant-Token")
+	return warrantToken, nil
 }
 
 func Delete(objectTypeId string) (string, error) {

--- a/objecttype/client.go
+++ b/objecttype/client.go
@@ -28,6 +28,7 @@ func (c Client) Create(params *warrant.ObjectTypeParams) (*warrant.ObjectType, e
 	if err != nil {
 		return nil, warrant.WrapError("Error reading response", err)
 	}
+	defer resp.Body.Close()
 	var newObjectType warrant.ObjectType
 	err = json.Unmarshal([]byte(body), &newObjectType)
 	if err != nil {
@@ -51,6 +52,7 @@ func (c Client) Get(objectTypeId string, params *warrant.ObjectTypeParams) (*war
 	if err != nil {
 		return nil, warrant.WrapError("Error reading response", err)
 	}
+	defer resp.Body.Close()
 	var foundObjectType warrant.ObjectType
 	err = json.Unmarshal([]byte(body), &foundObjectType)
 	if err != nil {
@@ -72,6 +74,7 @@ func (c Client) Update(objectTypeId string, params *warrant.ObjectTypeParams) (*
 	if err != nil {
 		return nil, warrant.WrapError("Error reading response", err)
 	}
+	defer resp.Body.Close()
 	var updatedObjectType warrant.ObjectType
 	err = json.Unmarshal([]byte(body), &updatedObjectType)
 	if err != nil {
@@ -95,6 +98,7 @@ func (c Client) BatchUpdate(params []warrant.ObjectTypeParams) ([]warrant.Object
 	if err != nil {
 		return nil, warrant.WrapError("Error reading response", err)
 	}
+	defer resp.Body.Close()
 	var updatedObjectTypes []warrant.ObjectType
 	err = json.Unmarshal([]byte(body), &updatedObjectTypes)
 	if err != nil {
@@ -116,6 +120,7 @@ func (c Client) Delete(objectTypeId string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer resp.Body.Close()
 	warrantToken := resp.Header.Get("Warrant-Token")
 	return warrantToken, nil
 }
@@ -139,6 +144,7 @@ func (c Client) ListObjectTypes(listParams *warrant.ListObjectTypeParams) (warra
 	if err != nil {
 		return objectTypesListResponse, warrant.WrapError("Error reading response", err)
 	}
+	defer resp.Body.Close()
 	err = json.Unmarshal([]byte(body), &objectTypesListResponse)
 	if err != nil {
 		return objectTypesListResponse, warrant.WrapError("Invalid response from server", err)

--- a/params.go
+++ b/params.go
@@ -1,7 +1,7 @@
 package warrant
 
 type RequestOptions struct {
-	WarrantToken string
+	WarrantToken string `json:"warrantToken,omitempty" url:"warrantToken,omitempty"`
 }
 
 func (requestOptions *RequestOptions) SetWarrantToken(token string) {

--- a/permission.go
+++ b/permission.go
@@ -3,9 +3,8 @@ package warrant
 const ObjectTypePermission = "permission"
 
 type Permission struct {
-	PermissionId string `json:"permissionId"`
-	Name         string `json:"name,omitempty"`
-	Description  string `json:"description,omitempty"`
+	PermissionId string                 `json:"permissionId"`
+	Meta         map[string]interface{} `json:"meta,omitempty"`
 }
 
 func (permission Permission) GetObjectType() string {
@@ -22,7 +21,6 @@ type ListPermissionParams struct {
 
 type PermissionParams struct {
 	RequestOptions
-	PermissionId string `json:"permissionId"`
-	Name         string `json:"name,omitempty"`
-	Description  string `json:"description,omitempty"`
+	PermissionId string                 `json:"permissionId"`
+	Meta         map[string]interface{} `json:"meta,omitempty"`
 }

--- a/permission/client.go
+++ b/permission/client.go
@@ -171,7 +171,7 @@ func AssignPermissionToRole(permissionId string, roleId string) (*warrant.Warran
 	return getClient().AssignPermissionToRole(permissionId, roleId)
 }
 
-func (c Client) RemovePermissionFromRole(permissionId string, roleId string) error {
+func (c Client) RemovePermissionFromRole(permissionId string, roleId string) (string, error) {
 	return warrant.NewClient(c.apiClient.Config).Delete(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypePermission,
 		ObjectId:   permissionId,
@@ -183,7 +183,7 @@ func (c Client) RemovePermissionFromRole(permissionId string, roleId string) err
 	})
 }
 
-func RemovePermissionFromRole(permissionId string, roleId string) error {
+func RemovePermissionFromRole(permissionId string, roleId string) (string, error) {
 	return getClient().RemovePermissionFromRole(permissionId, roleId)
 }
 
@@ -234,7 +234,7 @@ func AssignPermissionToUser(permissionId string, userId string) (*warrant.Warran
 	return getClient().AssignPermissionToUser(permissionId, userId)
 }
 
-func (c Client) RemovePermissionFromUser(permissionId string, userId string) error {
+func (c Client) RemovePermissionFromUser(permissionId string, userId string) (string, error) {
 	return warrant.NewClient(c.apiClient.Config).Delete(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypePermission,
 		ObjectId:   permissionId,
@@ -246,7 +246,7 @@ func (c Client) RemovePermissionFromUser(permissionId string, userId string) err
 	})
 }
 
-func RemovePermissionFromUser(permissionId string, userId string) error {
+func RemovePermissionFromUser(permissionId string, userId string) (string, error) {
 	return getClient().RemovePermissionFromUser(permissionId, userId)
 }
 

--- a/permission/client.go
+++ b/permission/client.go
@@ -84,11 +84,11 @@ func Update(permissionId string, params *warrant.PermissionParams) (*warrant.Per
 	return getClient().Update(permissionId, params)
 }
 
-func (c Client) Delete(permissionId string) error {
+func (c Client) Delete(permissionId string) (string, error) {
 	return object.Delete(warrant.ObjectTypePermission, permissionId)
 }
 
-func Delete(permissionId string) error {
+func Delete(permissionId string) (string, error) {
 	return getClient().Delete(permissionId)
 }
 

--- a/pricingtier.go
+++ b/pricingtier.go
@@ -3,7 +3,8 @@ package warrant
 const ObjectTypePricingTier = "pricing-tier"
 
 type PricingTier struct {
-	PricingTierId string `json:"pricingTierId"`
+	PricingTierId string                 `json:"pricingTierId"`
+	Meta          map[string]interface{} `json:"meta,omitempty"`
 }
 
 func (pricingTier PricingTier) GetObjectType() string {
@@ -20,5 +21,6 @@ type ListPricingTierParams struct {
 
 type PricingTierParams struct {
 	RequestOptions
-	PricingTierId string `json:"pricingTierId"`
+	PricingTierId string                 `json:"pricingTierId"`
+	Meta          map[string]interface{} `json:"meta,omitempty"`
 }

--- a/pricingtier/client.go
+++ b/pricingtier/client.go
@@ -171,7 +171,7 @@ func AssignPricingTierToTenant(pricingTierId string, tenantId string) (*warrant.
 	return getClient().AssignPricingTierToTenant(pricingTierId, tenantId)
 }
 
-func (c Client) RemovePricingTierFromTenant(pricingTierId string, tenantId string) error {
+func (c Client) RemovePricingTierFromTenant(pricingTierId string, tenantId string) (string, error) {
 	return warrant.NewClient(c.apiClient.Config).Delete(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypePricingTier,
 		ObjectId:   pricingTierId,
@@ -183,7 +183,7 @@ func (c Client) RemovePricingTierFromTenant(pricingTierId string, tenantId strin
 	})
 }
 
-func RemovePricingTierFromTenant(pricingTierId string, tenantId string) error {
+func RemovePricingTierFromTenant(pricingTierId string, tenantId string) (string, error) {
 	return getClient().RemovePricingTierFromTenant(pricingTierId, tenantId)
 }
 
@@ -234,7 +234,7 @@ func AssignPricingTierToUser(pricingTierId string, userId string) (*warrant.Warr
 	return getClient().AssignPricingTierToUser(pricingTierId, userId)
 }
 
-func (c Client) RemovePricingTierFromUser(pricingTierId string, userId string) error {
+func (c Client) RemovePricingTierFromUser(pricingTierId string, userId string) (string, error) {
 	return warrant.NewClient(c.apiClient.Config).Delete(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypePricingTier,
 		ObjectId:   pricingTierId,
@@ -246,7 +246,7 @@ func (c Client) RemovePricingTierFromUser(pricingTierId string, userId string) e
 	})
 }
 
-func RemovePricingTierFromUser(pricingTierId string, userId string) error {
+func RemovePricingTierFromUser(pricingTierId string, userId string) (string, error) {
 	return getClient().RemovePricingTierFromUser(pricingTierId, userId)
 }
 

--- a/pricingtier/client.go
+++ b/pricingtier/client.go
@@ -84,11 +84,11 @@ func Update(pricingTierId string, params *warrant.PricingTierParams) (*warrant.P
 	return getClient().Update(pricingTierId, params)
 }
 
-func (c Client) Delete(pricingTierId string) error {
+func (c Client) Delete(pricingTierId string) (string, error) {
 	return object.Delete(warrant.ObjectTypePricingTier, pricingTierId)
 }
 
-func Delete(pricingTierId string) error {
+func Delete(pricingTierId string) (string, error) {
 	return getClient().Delete(pricingTierId)
 }
 

--- a/query.go
+++ b/query.go
@@ -2,7 +2,6 @@ package warrant
 
 type QueryParams struct {
 	ListParams
-	lastId *string
 }
 
 type QueryResponse struct {

--- a/role.go
+++ b/role.go
@@ -3,9 +3,8 @@ package warrant
 const ObjectTypeRole = "role"
 
 type Role struct {
-	RoleId      string `json:"roleId"`
-	Name        string `json:"name,omitempty"`
-	Description string `json:"description,omitempty"`
+	RoleId string                 `json:"roleId"`
+	Meta   map[string]interface{} `json:"meta,omitempty"`
 }
 
 func (role Role) GetObjectType() string {
@@ -22,7 +21,6 @@ type ListRoleParams struct {
 
 type RoleParams struct {
 	RequestOptions
-	RoleId      string `json:"roleId"`
-	Name        string `json:"name,omitempty"`
-	Description string `json:"description,omitempty"`
+	RoleId string                 `json:"roleId"`
+	Meta   map[string]interface{} `json:"meta,omitempty"`
 }

--- a/role/client.go
+++ b/role/client.go
@@ -84,11 +84,11 @@ func Update(roleId string, params *warrant.RoleParams) (*warrant.Role, error) {
 	return getClient().Update(roleId, params)
 }
 
-func (c Client) Delete(roleId string) error {
+func (c Client) Delete(roleId string) (string, error) {
 	return object.Delete(warrant.ObjectTypeRole, roleId)
 }
 
-func Delete(roleId string) error {
+func Delete(roleId string) (string, error) {
 	return getClient().Delete(roleId)
 }
 

--- a/role/client.go
+++ b/role/client.go
@@ -171,7 +171,7 @@ func AssignRoleToUser(roleId string, userId string) (*warrant.Warrant, error) {
 	return getClient().AssignRoleToUser(roleId, userId)
 }
 
-func (c Client) RemoveRoleFromUser(roleId string, userId string) error {
+func (c Client) RemoveRoleFromUser(roleId string, userId string) (string, error) {
 	return warrant.NewClient(c.apiClient.Config).Delete(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypeRole,
 		ObjectId:   roleId,
@@ -183,7 +183,7 @@ func (c Client) RemoveRoleFromUser(roleId string, userId string) error {
 	})
 }
 
-func RemoveRoleFromUser(roleId string, userId string) error {
+func RemoveRoleFromUser(roleId string, userId string) (string, error) {
 	return getClient().RemoveRoleFromUser(roleId, userId)
 }
 

--- a/session/client.go
+++ b/session/client.go
@@ -32,6 +32,7 @@ func (c Client) CreateAuthorizationSession(params *warrant.AuthorizationSessionP
 	if err != nil {
 		return "", warrant.WrapError("Error reading response", err)
 	}
+	defer resp.Body.Close()
 	var response map[string]string
 	err = json.Unmarshal([]byte(body), &response)
 	if err != nil {
@@ -67,6 +68,7 @@ func (c Client) CreateSelfServiceSession(params *warrant.SelfServiceSessionParam
 	if err != nil {
 		return "", warrant.WrapError("Error reading response", err)
 	}
+	defer resp.Body.Close()
 	var response map[string]string
 	err = json.Unmarshal([]byte(body), &response)
 	if err != nil {

--- a/tenant.go
+++ b/tenant.go
@@ -1,13 +1,10 @@
 package warrant
 
-import "time"
-
 const ObjectTypeTenant = "tenant"
 
 type Tenant struct {
-	TenantId  string    `json:"tenantId"`
-	Name      string    `json:"name,omitempty"`
-	CreatedAt time.Time `json:"createdAt"`
+	TenantId string                 `json:"tenantId"`
+	Meta     map[string]interface{} `json:"meta,omitempty"`
 }
 
 func (tenant Tenant) GetObjectType() string {
@@ -24,6 +21,6 @@ type ListTenantParams struct {
 
 type TenantParams struct {
 	RequestOptions
-	TenantId string `json:"tenantId,omitempty"`
-	Name     string `json:"name,omitempty"`
+	TenantId string                 `json:"tenantId,omitempty"`
+	Meta     map[string]interface{} `json:"meta,omitempty"`
 }

--- a/tenant/client.go
+++ b/tenant/client.go
@@ -115,15 +115,15 @@ func Update(tenantId string, params *warrant.TenantParams) (*warrant.Tenant, err
 	return getClient().Update(tenantId, params)
 }
 
-func (c Client) Delete(tenantId string) error {
+func (c Client) Delete(tenantId string) (string, error) {
 	return object.Delete(warrant.ObjectTypeTenant, tenantId)
 }
 
-func Delete(tenantId string) error {
+func Delete(tenantId string) (string, error) {
 	return getClient().Delete(tenantId)
 }
 
-func (c Client) BatchDelete(params []warrant.TenantParams) error {
+func (c Client) BatchDelete(params []warrant.TenantParams) (string, error) {
 	objectsToDelete := make([]warrant.ObjectParams, 0)
 	for _, tenantParam := range params {
 		objectsToDelete = append(objectsToDelete, warrant.ObjectParams{
@@ -134,15 +134,15 @@ func (c Client) BatchDelete(params []warrant.TenantParams) error {
 		})
 	}
 
-	err := object.BatchDelete(objectsToDelete)
+	warrantToken, err := object.BatchDelete(objectsToDelete)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	return nil
+	return warrantToken, nil
 }
 
-func BatchDelete(params []warrant.TenantParams) error {
+func BatchDelete(params []warrant.TenantParams) (string, error) {
 	return getClient().BatchDelete(params)
 }
 

--- a/tenant/client.go
+++ b/tenant/client.go
@@ -1,12 +1,10 @@
 package tenant
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
 
-	"github.com/google/go-querystring/query"
 	"github.com/warrant-dev/warrant-go/v5"
+	"github.com/warrant-dev/warrant-go/v5/object"
 )
 
 type Client struct {
@@ -20,20 +18,24 @@ func NewClient(config warrant.ClientConfig) Client {
 }
 
 func (c Client) Create(params *warrant.TenantParams) (*warrant.Tenant, error) {
-	resp, err := c.apiClient.MakeRequest("POST", "/v1/tenants", params, &warrant.RequestOptions{})
+	objectParams := warrant.ObjectParams{
+		ObjectType:     warrant.ObjectTypeTenant,
+		RequestOptions: params.RequestOptions,
+	}
+	if params.TenantId != "" {
+		objectParams.ObjectId = params.TenantId
+	}
+	if params.Meta != nil {
+		objectParams.Meta = params.Meta
+	}
+	object, err := object.Create(&objectParams)
 	if err != nil {
 		return nil, err
 	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, warrant.WrapError("Error reading response", err)
-	}
-	var newTenant warrant.Tenant
-	err = json.Unmarshal([]byte(body), &newTenant)
-	if err != nil {
-		return nil, warrant.WrapError("Invalid response from server", err)
-	}
-	return &newTenant, nil
+	return &warrant.Tenant{
+		TenantId: object.ObjectId,
+		Meta:     object.Meta,
+	}, nil
 }
 
 func Create(params *warrant.TenantParams) (*warrant.Tenant, error) {
@@ -41,20 +43,30 @@ func Create(params *warrant.TenantParams) (*warrant.Tenant, error) {
 }
 
 func (c Client) BatchCreate(params []warrant.TenantParams) ([]warrant.Tenant, error) {
-	resp, err := c.apiClient.MakeRequest("POST", "/v1/tenants", params, &warrant.RequestOptions{})
+	objectsToCreate := make([]warrant.ObjectParams, 0)
+	for _, tenantParam := range params {
+		objectsToCreate = append(objectsToCreate, warrant.ObjectParams{
+			RequestOptions: tenantParam.RequestOptions,
+			ObjectType:     warrant.ObjectTypeTenant,
+			ObjectId:       tenantParam.TenantId,
+			Meta:           tenantParam.Meta,
+		})
+	}
+
+	createdObjects, err := object.BatchCreate(objectsToCreate)
 	if err != nil {
 		return nil, err
 	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, warrant.WrapError("Error reading response", err)
+
+	tenants := make([]warrant.Tenant, 0)
+	for _, createdObject := range createdObjects {
+		tenants = append(tenants, warrant.Tenant{
+			TenantId: createdObject.ObjectId,
+			Meta:     createdObject.Meta,
+		})
 	}
-	var createdTenants []warrant.Tenant
-	err = json.Unmarshal([]byte(body), &createdTenants)
-	if err != nil {
-		return nil, warrant.WrapError("Invalid response from server", err)
-	}
-	return createdTenants, nil
+
+	return tenants, nil
 }
 
 func BatchCreate(params []warrant.TenantParams) ([]warrant.Tenant, error) {
@@ -62,20 +74,20 @@ func BatchCreate(params []warrant.TenantParams) ([]warrant.Tenant, error) {
 }
 
 func (c Client) Get(tenantId string, params *warrant.TenantParams) (*warrant.Tenant, error) {
-	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants/%s", tenantId), nil, &params.RequestOptions)
+	objectParams := warrant.ObjectParams{
+		ObjectType:     warrant.ObjectTypeTenant,
+		ObjectId:       tenantId,
+		RequestOptions: params.RequestOptions,
+		Meta:           params.Meta,
+	}
+	object, err := object.Get(warrant.ObjectTypeTenant, tenantId, &objectParams)
 	if err != nil {
 		return nil, err
 	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, warrant.WrapError("Error reading response", err)
-	}
-	var foundTenant warrant.Tenant
-	err = json.Unmarshal([]byte(body), &foundTenant)
-	if err != nil {
-		return nil, warrant.WrapError("Invalid response from server", err)
-	}
-	return &foundTenant, nil
+	return &warrant.Tenant{
+		TenantId: object.ObjectId,
+		Meta:     object.Meta,
+	}, nil
 }
 
 func Get(tenantId string, params *warrant.TenantParams) (*warrant.Tenant, error) {
@@ -83,20 +95,20 @@ func Get(tenantId string, params *warrant.TenantParams) (*warrant.Tenant, error)
 }
 
 func (c Client) Update(tenantId string, params *warrant.TenantParams) (*warrant.Tenant, error) {
-	resp, err := c.apiClient.MakeRequest("PUT", fmt.Sprintf("/v1/tenants/%s", tenantId), params, &warrant.RequestOptions{})
+	objectParams := warrant.ObjectParams{
+		ObjectType:     warrant.ObjectTypeTenant,
+		ObjectId:       tenantId,
+		RequestOptions: params.RequestOptions,
+		Meta:           params.Meta,
+	}
+	object, err := object.Update(warrant.ObjectTypeTenant, tenantId, &objectParams)
 	if err != nil {
 		return nil, err
 	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, warrant.WrapError("Error reading response", err)
-	}
-	var updatedTenant warrant.Tenant
-	err = json.Unmarshal([]byte(body), &updatedTenant)
-	if err != nil {
-		return nil, warrant.WrapError("Invalid response from server", err)
-	}
-	return &updatedTenant, nil
+	return &warrant.Tenant{
+		TenantId: object.ObjectId,
+		Meta:     object.Meta,
+	}, nil
 }
 
 func Update(tenantId string, params *warrant.TenantParams) (*warrant.Tenant, error) {
@@ -104,77 +116,96 @@ func Update(tenantId string, params *warrant.TenantParams) (*warrant.Tenant, err
 }
 
 func (c Client) Delete(tenantId string) error {
-	resp, err := c.apiClient.MakeRequest("DELETE", fmt.Sprintf("/v1/tenants/%s", tenantId), nil, &warrant.RequestOptions{})
-	if err != nil {
-		return err
-	}
-	respStatus := resp.StatusCode
-	if respStatus < 200 || respStatus >= 400 {
-		msg, err := io.ReadAll(resp.Body)
-		errMsg := ""
-		if err == nil {
-			errMsg = string(msg)
-		}
-		return warrant.Error{
-			Message: fmt.Sprintf("HTTP %d %s", respStatus, errMsg),
-		}
-	}
-	return nil
+	return object.Delete(warrant.ObjectTypeTenant, tenantId)
 }
 
 func Delete(tenantId string) error {
 	return getClient().Delete(tenantId)
 }
 
-func (c Client) ListTenants(listParams *warrant.ListTenantParams) ([]warrant.Tenant, error) {
-	queryParams, err := query.Values(listParams)
-	if err != nil {
-		return nil, warrant.WrapError("Could not parse listParams", err)
+func (c Client) BatchDelete(params []warrant.TenantParams) error {
+	objectsToDelete := make([]warrant.ObjectParams, 0)
+	for _, tenantParam := range params {
+		objectsToDelete = append(objectsToDelete, warrant.ObjectParams{
+			RequestOptions: tenantParam.RequestOptions,
+			ObjectType:     warrant.ObjectTypeTenant,
+			ObjectId:       tenantParam.TenantId,
+			Meta:           tenantParam.Meta,
+		})
 	}
 
-	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants?%s", queryParams.Encode()), nil, &listParams.RequestOptions)
+	err := object.BatchDelete(objectsToDelete)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, warrant.WrapError("Error reading response", err)
-	}
-	var tenants []warrant.Tenant
-	err = json.Unmarshal([]byte(body), &tenants)
-	if err != nil {
-		return nil, warrant.WrapError("Invalid response from server", err)
-	}
-	return tenants, nil
+
+	return nil
 }
 
-func ListTenants(listParams *warrant.ListTenantParams) ([]warrant.Tenant, error) {
+func BatchDelete(params []warrant.TenantParams) error {
+	return getClient().BatchDelete(params)
+}
+
+func (c Client) ListTenants(listParams *warrant.ListTenantParams) (warrant.ListResponse[warrant.Tenant], error) {
+	var tenantsListResponse warrant.ListResponse[warrant.Tenant]
+
+	objectsListResponse, err := object.ListObjects(&warrant.ListObjectParams{
+		ListParams: listParams.ListParams,
+		ObjectType: warrant.ObjectTypeTenant,
+	})
+	if err != nil {
+		return tenantsListResponse, err
+	}
+
+	tenants := make([]warrant.Tenant, 0)
+	for _, object := range objectsListResponse.Results {
+		tenants = append(tenants, warrant.Tenant{
+			TenantId: object.ObjectId,
+			Meta:     object.Meta,
+		})
+	}
+
+	tenantsListResponse = warrant.ListResponse[warrant.Tenant]{
+		Results:    tenants,
+		PrevCursor: objectsListResponse.PrevCursor,
+		NextCursor: objectsListResponse.NextCursor,
+	}
+
+	return tenantsListResponse, nil
+}
+
+func ListTenants(listParams *warrant.ListTenantParams) (warrant.ListResponse[warrant.Tenant], error) {
 	return getClient().ListTenants(listParams)
 }
 
-func (c Client) ListTenantsForUser(userId string, listParams *warrant.ListTenantParams) ([]warrant.Tenant, error) {
-	queryParams, err := query.Values(listParams)
+func (c Client) ListTenantsForUser(userId string, listParams *warrant.ListTenantParams) (warrant.ListResponse[warrant.Tenant], error) {
+	var tenantsListResponse warrant.ListResponse[warrant.Tenant]
+
+	queryResponse, err := warrant.Query(fmt.Sprintf("select tenant where user:%s is *", userId), &warrant.QueryParams{
+		ListParams: listParams.ListParams,
+	})
 	if err != nil {
-		return nil, warrant.WrapError("Could not parse listParams", err)
+		return tenantsListResponse, err
 	}
 
-	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s/tenants?%s", userId, queryParams.Encode()), nil, &listParams.RequestOptions)
-	if err != nil {
-		return nil, err
+	tenants := make([]warrant.Tenant, 0)
+	for _, queryResult := range queryResponse.Results {
+		tenants = append(tenants, warrant.Tenant{
+			TenantId: queryResult.ObjectId,
+			Meta:     queryResult.Meta,
+		})
 	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, warrant.WrapError("Error reading response", err)
+
+	tenantsListResponse = warrant.ListResponse[warrant.Tenant]{
+		Results:    tenants,
+		PrevCursor: queryResponse.PrevCursor,
+		NextCursor: queryResponse.NextCursor,
 	}
-	var tenants []warrant.Tenant
-	err = json.Unmarshal([]byte(body), &tenants)
-	if err != nil {
-		return nil, warrant.WrapError("Invalid response from server", err)
-	}
-	return tenants, nil
+
+	return tenantsListResponse, nil
 }
 
-func ListTenantsForUser(userId string, listParams *warrant.ListTenantParams) ([]warrant.Tenant, error) {
+func ListTenantsForUser(userId string, listParams *warrant.ListTenantParams) (warrant.ListResponse[warrant.Tenant], error) {
 	return getClient().ListTenantsForUser(userId, listParams)
 }
 

--- a/user.go
+++ b/user.go
@@ -3,8 +3,8 @@ package warrant
 const ObjectTypeUser = "user"
 
 type User struct {
-	UserId string `json:"userId"`
-	Email  string `json:"email,omitempty"`
+	UserId string                 `json:"userId"`
+	Meta   map[string]interface{} `json:"meta,omitempty"`
 }
 
 func (user User) GetObjectType() string {
@@ -21,6 +21,6 @@ type ListUserParams struct {
 
 type UserParams struct {
 	RequestOptions
-	UserId string `json:"userId,omitempty"`
-	Email  string `json:"email,omitempty"`
+	UserId string                 `json:"userId,omitempty"`
+	Meta   map[string]interface{} `json:"meta,omitempty"`
 }

--- a/user/client.go
+++ b/user/client.go
@@ -115,15 +115,15 @@ func Update(userId string, params *warrant.UserParams) (*warrant.User, error) {
 	return getClient().Update(userId, params)
 }
 
-func (c Client) Delete(userId string) error {
+func (c Client) Delete(userId string) (string, error) {
 	return object.Delete(warrant.ObjectTypeUser, userId)
 }
 
-func Delete(userId string) error {
+func Delete(userId string) (string, error) {
 	return getClient().Delete(userId)
 }
 
-func (c Client) BatchDelete(params []warrant.UserParams) error {
+func (c Client) BatchDelete(params []warrant.UserParams) (string, error) {
 	objectsToDelete := make([]warrant.ObjectParams, 0)
 	for _, userParam := range params {
 		objectsToDelete = append(objectsToDelete, warrant.ObjectParams{
@@ -134,15 +134,15 @@ func (c Client) BatchDelete(params []warrant.UserParams) error {
 		})
 	}
 
-	err := object.BatchDelete(objectsToDelete)
+	warrantToken, err := object.BatchDelete(objectsToDelete)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	return nil
+	return warrantToken, nil
 }
 
-func BatchDelete(params []warrant.UserParams) error {
+func BatchDelete(params []warrant.UserParams) (string, error) {
 	return getClient().BatchDelete(params)
 }
 

--- a/user/client.go
+++ b/user/client.go
@@ -225,7 +225,7 @@ func AssignUserToTenant(userId string, tenantId string, role string) (*warrant.W
 	return getClient().AssignUserToTenant(userId, tenantId, role)
 }
 
-func (c Client) RemoveUserFromTenant(userId string, tenantId string, role string) error {
+func (c Client) RemoveUserFromTenant(userId string, tenantId string, role string) (string, error) {
 	return warrant.Delete(&warrant.WarrantParams{
 		ObjectType: warrant.ObjectTypeTenant,
 		ObjectId:   tenantId,
@@ -237,7 +237,7 @@ func (c Client) RemoveUserFromTenant(userId string, tenantId string, role string
 	})
 }
 
-func RemoveUserFromTenant(userId string, tenantId string, role string) error {
+func RemoveUserFromTenant(userId string, tenantId string, role string) (string, error) {
 	return getClient().RemoveUserFromTenant(userId, tenantId, role)
 }
 

--- a/user/client.go
+++ b/user/client.go
@@ -1,12 +1,10 @@
 package user
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
 
-	"github.com/google/go-querystring/query"
 	"github.com/warrant-dev/warrant-go/v5"
+	"github.com/warrant-dev/warrant-go/v5/object"
 )
 
 type Client struct {
@@ -20,20 +18,24 @@ func NewClient(config warrant.ClientConfig) Client {
 }
 
 func (c Client) Create(params *warrant.UserParams) (*warrant.User, error) {
-	resp, err := c.apiClient.MakeRequest("POST", "/v1/users", params, &warrant.RequestOptions{})
+	objectParams := warrant.ObjectParams{
+		ObjectType:     warrant.ObjectTypeUser,
+		RequestOptions: params.RequestOptions,
+	}
+	if params.UserId != "" {
+		objectParams.ObjectId = params.UserId
+	}
+	if params.Meta != nil {
+		objectParams.Meta = params.Meta
+	}
+	object, err := object.Create(&objectParams)
 	if err != nil {
 		return nil, err
 	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, warrant.WrapError("Error reading response", err)
-	}
-	var newUser warrant.User
-	err = json.Unmarshal([]byte(body), &newUser)
-	if err != nil {
-		return nil, warrant.WrapError("Invalid response from server", err)
-	}
-	return &newUser, nil
+	return &warrant.User{
+		UserId: object.ObjectId,
+		Meta:   object.Meta,
+	}, nil
 }
 
 func Create(params *warrant.UserParams) (*warrant.User, error) {
@@ -41,20 +43,30 @@ func Create(params *warrant.UserParams) (*warrant.User, error) {
 }
 
 func (c Client) BatchCreate(params []warrant.UserParams) ([]warrant.User, error) {
-	resp, err := c.apiClient.MakeRequest("POST", "/v1/users", params, &warrant.RequestOptions{})
+	objectsToCreate := make([]warrant.ObjectParams, 0)
+	for _, userParam := range params {
+		objectsToCreate = append(objectsToCreate, warrant.ObjectParams{
+			RequestOptions: userParam.RequestOptions,
+			ObjectType:     warrant.ObjectTypeUser,
+			ObjectId:       userParam.UserId,
+			Meta:           userParam.Meta,
+		})
+	}
+
+	createdObjects, err := object.BatchCreate(objectsToCreate)
 	if err != nil {
 		return nil, err
 	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, warrant.WrapError("Error reading response", err)
+
+	users := make([]warrant.User, 0)
+	for _, createdObject := range createdObjects {
+		users = append(users, warrant.User{
+			UserId: createdObject.ObjectId,
+			Meta:   createdObject.Meta,
+		})
 	}
-	var createdUsers []warrant.User
-	err = json.Unmarshal([]byte(body), &createdUsers)
-	if err != nil {
-		return nil, warrant.WrapError("Invalid response from server", err)
-	}
-	return createdUsers, nil
+
+	return users, nil
 }
 
 func BatchCreate(params []warrant.UserParams) ([]warrant.User, error) {
@@ -62,20 +74,20 @@ func BatchCreate(params []warrant.UserParams) ([]warrant.User, error) {
 }
 
 func (c Client) Get(userId string, params *warrant.UserParams) (*warrant.User, error) {
-	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/users/%s", userId), nil, &params.RequestOptions)
+	objectParams := warrant.ObjectParams{
+		ObjectType:     warrant.ObjectTypeUser,
+		ObjectId:       userId,
+		RequestOptions: params.RequestOptions,
+		Meta:           params.Meta,
+	}
+	object, err := object.Get(warrant.ObjectTypeUser, userId, &objectParams)
 	if err != nil {
 		return nil, err
 	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, warrant.WrapError("Error reading response", err)
-	}
-	var foundUser warrant.User
-	err = json.Unmarshal([]byte(body), &foundUser)
-	if err != nil {
-		return nil, warrant.WrapError("Invalid response from server", err)
-	}
-	return &foundUser, nil
+	return &warrant.User{
+		UserId: object.ObjectId,
+		Meta:   object.Meta,
+	}, nil
 }
 
 func Get(userId string, params *warrant.UserParams) (*warrant.User, error) {
@@ -83,20 +95,20 @@ func Get(userId string, params *warrant.UserParams) (*warrant.User, error) {
 }
 
 func (c Client) Update(userId string, params *warrant.UserParams) (*warrant.User, error) {
-	resp, err := c.apiClient.MakeRequest("PUT", fmt.Sprintf("/v1/users/%s", userId), params, &warrant.RequestOptions{})
+	objectParams := warrant.ObjectParams{
+		ObjectType:     warrant.ObjectTypeUser,
+		ObjectId:       userId,
+		RequestOptions: params.RequestOptions,
+		Meta:           params.Meta,
+	}
+	object, err := object.Update(warrant.ObjectTypeUser, userId, &objectParams)
 	if err != nil {
 		return nil, err
 	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, warrant.WrapError("Error reading response", err)
-	}
-	var updatedUser warrant.User
-	err = json.Unmarshal([]byte(body), &updatedUser)
-	if err != nil {
-		return nil, warrant.WrapError("Invalid response from server", err)
-	}
-	return &updatedUser, nil
+	return &warrant.User{
+		UserId: object.ObjectId,
+		Meta:   object.Meta,
+	}, nil
 }
 
 func Update(userId string, params *warrant.UserParams) (*warrant.User, error) {
@@ -104,66 +116,96 @@ func Update(userId string, params *warrant.UserParams) (*warrant.User, error) {
 }
 
 func (c Client) Delete(userId string) error {
-	_, err := c.apiClient.MakeRequest("DELETE", fmt.Sprintf("/v1/users/%s", userId), nil, &warrant.RequestOptions{})
-	if err != nil {
-		return err
-	}
-	return nil
+	return object.Delete(warrant.ObjectTypeUser, userId)
 }
 
 func Delete(userId string) error {
 	return getClient().Delete(userId)
 }
 
-func (c Client) ListUsers(listParams *warrant.ListUserParams) ([]warrant.User, error) {
-	queryParams, err := query.Values(listParams)
-	if err != nil {
-		return nil, warrant.WrapError("Could not parse listParams", err)
+func (c Client) BatchDelete(params []warrant.UserParams) error {
+	objectsToDelete := make([]warrant.ObjectParams, 0)
+	for _, userParam := range params {
+		objectsToDelete = append(objectsToDelete, warrant.ObjectParams{
+			RequestOptions: userParam.RequestOptions,
+			ObjectType:     warrant.ObjectTypeUser,
+			ObjectId:       userParam.UserId,
+			Meta:           userParam.Meta,
+		})
 	}
 
-	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/users?%s", queryParams.Encode()), nil, &listParams.RequestOptions)
+	err := object.BatchDelete(objectsToDelete)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, warrant.WrapError("Error reading response", err)
-	}
-	var users []warrant.User
-	err = json.Unmarshal([]byte(body), &users)
-	if err != nil {
-		return nil, warrant.WrapError("Invalid response from server", err)
-	}
-	return users, nil
+
+	return nil
 }
 
-func ListUsers(listParams *warrant.ListUserParams) ([]warrant.User, error) {
+func BatchDelete(params []warrant.UserParams) error {
+	return getClient().BatchDelete(params)
+}
+
+func (c Client) ListUsers(listParams *warrant.ListUserParams) (warrant.ListResponse[warrant.User], error) {
+	var usersListResponse warrant.ListResponse[warrant.User]
+
+	objectsListResponse, err := object.ListObjects(&warrant.ListObjectParams{
+		ListParams: listParams.ListParams,
+		ObjectType: warrant.ObjectTypeUser,
+	})
+	if err != nil {
+		return usersListResponse, err
+	}
+
+	users := make([]warrant.User, 0)
+	for _, object := range objectsListResponse.Results {
+		users = append(users, warrant.User{
+			UserId: object.ObjectId,
+			Meta:   object.Meta,
+		})
+	}
+
+	usersListResponse = warrant.ListResponse[warrant.User]{
+		Results:    users,
+		PrevCursor: objectsListResponse.PrevCursor,
+		NextCursor: objectsListResponse.NextCursor,
+	}
+
+	return usersListResponse, nil
+}
+
+func ListUsers(listParams *warrant.ListUserParams) (warrant.ListResponse[warrant.User], error) {
 	return getClient().ListUsers(listParams)
 }
 
-func (c Client) ListUsersForTenant(tenantId string, listParams *warrant.ListUserParams) ([]warrant.User, error) {
-	queryParams, err := query.Values(listParams)
+func (c Client) ListUsersForTenant(tenantId string, listParams *warrant.ListUserParams) (warrant.ListResponse[warrant.User], error) {
+	var usersListResponse warrant.ListResponse[warrant.User]
+
+	queryResponse, err := warrant.Query(fmt.Sprintf("select * of type user for tenant:%s", tenantId), &warrant.QueryParams{
+		ListParams: listParams.ListParams,
+	})
 	if err != nil {
-		return nil, warrant.WrapError("Could not parse listParams", err)
+		return usersListResponse, err
 	}
 
-	resp, err := c.apiClient.MakeRequest("GET", fmt.Sprintf("/v1/tenants/%s/users?%s", tenantId, queryParams.Encode()), nil, &listParams.RequestOptions)
-	if err != nil {
-		return nil, err
+	users := make([]warrant.User, 0)
+	for _, queryResult := range queryResponse.Results {
+		users = append(users, warrant.User{
+			UserId: queryResult.ObjectId,
+			Meta:   queryResult.Meta,
+		})
 	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, warrant.WrapError("Error reading response", err)
+
+	usersListResponse = warrant.ListResponse[warrant.User]{
+		Results:    users,
+		PrevCursor: queryResponse.PrevCursor,
+		NextCursor: queryResponse.NextCursor,
 	}
-	var users []warrant.User
-	err = json.Unmarshal([]byte(body), &users)
-	if err != nil {
-		return nil, warrant.WrapError("Invalid response from server", err)
-	}
-	return users, nil
+
+	return usersListResponse, nil
 }
 
-func ListUsersForTenant(tenantId string, listParams *warrant.ListUserParams) ([]warrant.User, error) {
+func ListUsersForTenant(tenantId string, listParams *warrant.ListUserParams) (warrant.ListResponse[warrant.User], error) {
 	return getClient().ListUsersForTenant(tenantId, listParams)
 }
 

--- a/warrant.go
+++ b/warrant.go
@@ -29,6 +29,10 @@ func (subject Subject) GetObjectId() string {
 	return subject.ObjectId
 }
 
+func (subject Subject) GetRelation() string {
+	return subject.Relation
+}
+
 type WarrantParams struct {
 	ObjectType string  `json:"objectType"`
 	ObjectId   string  `json:"objectId"`

--- a/warrant.go
+++ b/warrant.go
@@ -85,12 +85,31 @@ type WarrantCheck struct {
 }
 
 func (warrantCheck WarrantCheck) MarshalJSON() ([]byte, error) {
-	m := map[string]interface{}{
-		"objectType": warrantCheck.Object.GetObjectType(),
-		"objectId":   warrantCheck.Object.GetObjectId(),
-		"relation":   warrantCheck.Relation,
-		"subject":    warrantCheck.Subject,
-		"context":    warrantCheck.Context,
+	var m map[string]interface{}
+	subject, ok := warrantCheck.Subject.(*Subject)
+	if ok {
+		m = map[string]interface{}{
+			"objectType": warrantCheck.Object.GetObjectType(),
+			"objectId":   warrantCheck.Object.GetObjectId(),
+			"relation":   warrantCheck.Relation,
+			"subject": map[string]interface{}{
+				"objectType": subject.GetObjectType(),
+				"objectId":   subject.GetObjectId(),
+				"relation":   subject.GetRelation(),
+			},
+			"context": warrantCheck.Context,
+		}
+	} else {
+		m = map[string]interface{}{
+			"objectType": warrantCheck.Object.GetObjectType(),
+			"objectId":   warrantCheck.Object.GetObjectId(),
+			"relation":   warrantCheck.Relation,
+			"subject": map[string]interface{}{
+				"objectType": warrantCheck.Subject.GetObjectType(),
+				"objectId":   warrantCheck.Subject.GetObjectId(),
+			},
+			"context": warrantCheck.Context,
+		}
 	}
 
 	return json.Marshal(m)

--- a/warrant.go
+++ b/warrant.go
@@ -5,13 +5,13 @@ import (
 )
 
 type Warrant struct {
-	ObjectType string  `json:"objectType"`
-	ObjectId   string  `json:"objectId"`
-	Relation   string  `json:"relation"`
-	Subject    Subject `json:"subject"`
-	Policy     string  `json:"policy,omitempty"`
-	IsImplicit bool    `json:"isImplicit,omitempty"`
-	Wookie     string  `json:"wookie,omitempty"`
+	ObjectType   string  `json:"objectType"`
+	ObjectId     string  `json:"objectId"`
+	Relation     string  `json:"relation"`
+	Subject      Subject `json:"subject"`
+	Policy       string  `json:"policy,omitempty"`
+	IsImplicit   bool    `json:"isImplicit,omitempty"`
+	WarrantToken string  `json:"warrantToken,omitempty"`
 }
 
 type PolicyContext map[string]interface{}

--- a/warrant.go
+++ b/warrant.go
@@ -64,6 +64,8 @@ type ObjectParams struct {
 
 type ListObjectParams struct {
 	ListParams
+	ObjectType string `json:"objectType,omitempty" url:"objectType,omitempty"`
+	Query      string `json:"q,omitempty" url:"q,omitempty"`
 }
 
 type WarrantObject interface {

--- a/warrant.go
+++ b/warrant.go
@@ -11,6 +11,7 @@ type Warrant struct {
 	Subject    Subject `json:"subject"`
 	Policy     string  `json:"policy,omitempty"`
 	IsImplicit bool    `json:"isImplicit,omitempty"`
+	Wookie     string  `json:"wookie,omitempty"`
 }
 
 type PolicyContext map[string]interface{}


### PR DESCRIPTION
This PR makes changes to add support for the V2 endpoints of the Warrant API. 

Changes include:
- ObjectModule added for the object endpoints
- Batch create/delete support added for warrants
- List methods return a list result which includes an array of results along with an optional previous and next cursor for pagination
- Resource modules (e.g. `User`, `Role`) now include a meta field which contains metadata for the resource
- Writes for object types and warrants return a wookie either directly (deletes) or the returned resource (creates) 